### PR TITLE
Fixes typecheck task

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test-all": "yarn test && yarn test-e2e",
     "test-e2e": "yarn build && NODE_ENV=production jest test/e2e",
     "jest": "jest",
-    "typecheck": "tsc",
+    "typecheck": "tsc --noEmit",
     "hot-server": "cross-env NODE_ENV=development node --max_old_space_size=2096 server.js",
     "build-main": "cross-env NODE_ENV=production node ./node_modules/webpack/bin/webpack --config webpack.config.electron.js --progress --profile --colors",
     "build-renderer": "cross-env NODE_ENV=production node ./node_modules/webpack/bin/webpack --config webpack.config.production.js --progress --profile --colors",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
     "target": "es5",
     "moduleResolution": "node",
     "module": "commonjs",


### PR DESCRIPTION
Fixes `typecheck` task present in `package.json`
- Now the compiler does not emit output when the task is run
- Added option `baseUrl` to tsconfig.json so non-relative imports in
  test files are found when type-checking

## Usage

Just run `yarn typecheck` or `yarn typecheck --watch`