### PR TITLE
 Change interface name linting preference 

### DIFF
--- a/app/lib/storage/storageBackend.ts
+++ b/app/lib/storage/storageBackend.ts
@@ -2,7 +2,7 @@
  * This interface abstract away the underlying database backend from the vault
  * logic.
  */
-export default interface IStorageBackend {
+export default interface StorageBackend {
 
   put(key: Buffer, value: Buffer): Promise<void>
 

--- a/tslint.json
+++ b/tslint.json
@@ -15,7 +15,7 @@
     "forin": true,
     "import-spacing": true,
     "indent": [true, "spaces"],
-    "interface-name": true,
+    "interface-name": false,
     "jsdoc-format": true,
     "label-position": true,
     "linebreak-style": true,


### PR DESCRIPTION
+ Interface names don't need to start with "I" anymore
+ Renamed interface `IStorageBackend` → `StorageBackend`