### PR TITLE
Improve EncryptedStorage tests

### DIFF
--- a/test/app/lib/storage/encryptedStorage.spec.ts
+++ b/test/app/lib/storage/encryptedStorage.spec.ts
@@ -12,18 +12,21 @@ const globalStorage = new EncryptedStorage(mockedBackend, encryptionSettings)
 
 describe("EncryptedStorage", () => {
   it("should put a string", async () => {
-    const result = await globalStorage.put("foo", "bar")
-    expect(result).toBeUndefined()
+    expect(async () => {
+      await globalStorage.put("foo", "bar")
+    }).not.toThrow()
   })
 
   it("should put a number", async () => {
-    const result = await globalStorage.put("fee", 1234)
-    expect(result).toBeUndefined()
+    expect(async () => {
+      await globalStorage.put("fee", 1234)
+    }).not.toThrow()
   })
 
   it("should put an object", async () => {
-    const result = await globalStorage.put("faa", { beer: "cold" })
-    expect(result).toBeUndefined()
+    expect(async () => {
+      await globalStorage.put("faa", { beer: "cold" })
+    }).not.toThrow()
   })
 
   it("should get a string", async () => {


### PR DESCRIPTION
Tests proving the sucess of `Promise<void>` don't really need to use `expect()` at all.
If they resolve and don't throw any exceptions, they're just OK!