### PR TITLE
Relax lint rule for arrow functions

### DIFF
--- a/docs/STYLEGUIDE.md
+++ b/docs/STYLEGUIDE.md
@@ -36,27 +36,75 @@ const fooVar
 const barFunc = () => { }
 ```
 
-* Always use `const` and arrow-function syntax.
+* Always use function declarations in modules/namespaces
+
+> Reason: They play nicer with type signatures and for overloaded functions they are easier to read.
 
 **Bad**
-```ts
-function fooFunc() {
+
+``` ts
+const foo = function() {
+  // ...
+}
+
+namespace Foo {
+  const foo = function() {
+    // ...
+  }
 }
 ```
+
 **Good**
-```ts
-const fooFunc = () => { }
+
+``` ts
+function foo() {
+  // ...
+}
+
+namespace Foo {
+  function foo() {
+    // ...
+  }
+}
 ```
 
-To define function overloads you can use:
+* Always use `const` and arrow-function declaration for function expressions
 
-```ts
-const fooFunc: {
-  (number): number
-  (boolean): boolean
+> Reason: They are more compact syntactically and use lexical this
+
+``` ts
+const foo = function() {
   // ...
-} = (x: any) => {
+}
+```
+
+**Good**
+
+``` ts
+const foo = () => {
   // ...
+}
+```
+
+* Whenever possible use arrow-function syntax for class methods, specially for React components
+
+> Reason: They use lexical this
+
+``` ts
+class Foo extends Component {
+  function sayHello() {
+    // ...
+  }
+}
+```
+
+**Good**
+
+``` ts
+class Foo extends Component {
+  sayHello = () => {
+    // ...
+  }
 }
 ```
 
@@ -260,14 +308,14 @@ let foo:{x:number,y?:number} = {x:123}
 
 * Do not use `undefined` or `null` as return values in general, use instead an object like `{valid:boolean,value?:Foo}` instead.
 
-***Bad***
+**Bad**
 ```ts
 return null
 ```
 ```ts
 return undefined
 ```
-***Good***
+**Good**
 ```ts
 return {valid: false}
 ```

--- a/tslint.json
+++ b/tslint.json
@@ -67,7 +67,7 @@
     "object-literal-key-quotes": [true, "as-needed"],
     "object-literal-shorthand": true,
     "one-line": [true, "check-else", "check-whitespace", "check-open-brace"],
-    "only-arrow-functions": true,
+    "only-arrow-functions": [true, "allow-declarations"],
     "prefer-conditional-expression": true,
     "prefer-const": true,
     "prefer-for-of": true,


### PR DESCRIPTION
Relax [lint rule](https://palantir.github.io/tslint/rules/only-arrow-functions/) for arrow functions and update styleguide accordingly. Please, add your comments :)
Closes #54 