### PR TITLE
Add commitizen and commitlinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
 - yarn fmt-verify
 - yarn test
 - yarn test-e2e
+- commitlint-travis
 
 after_script: greenkeeper-lockfile-upload
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sheikah
 
 [![Join the chat at https://gitter.im/witnet/sheikah](https://badges.gitter.im/witnet/sheikah.svg)](https://gitter.im/witnet/sheikah?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 A [Witnet](https://witnet.io/) compatible desktop wallet and smart contracts development environment.
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = {extends: ['@commitlint/config-conventional']};

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "cross-env": "^5.1.4",
     "css-loader": "^0.28.11",
     "css-modules-require-hook": "^4.2.3",
+    "cz-conventional-changelog": "^2.1.0",
     "devtron": "^1.4.0",
     "electron": "1.8.6",
     "electron-builder": "^19.8.0",
@@ -181,5 +182,10 @@
   "devEngines": {
     "node": ">=6.x",
     "yarn": ">=1.x"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   "devDependencies": {
     "@commitlint/cli": "^6.2.0",
     "@commitlint/config-conventional": "^6.1.3",
+    "@commitlint/travis-cli": "^6.2.0",
     "@types/enzyme": "^3.1.1",
     "@types/history": "^4.5.2",
     "@types/jest": "^22.2.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "package-all": "yarn build && build -mwl",
     "lint": "tslint --project tsconfig.json --force app/**/*.ts typings/**/*.ts test/**/*.ts",
     "clean": "rimraf release dist",
+    "commit": "git-cz",
     "precommit": "lint-staged",
+    "commitmsg": "commitlint -e $GIT_PARAMS",
     "fmt-verify": "tsfmt --useTsfmt config/tsfmt.json --verify app/**/*.ts test/**/*.ts",
     "fmt": "tsfmt --useTsfmt config/tsfmt.json app/**/*.ts test/**/*.ts",
     "fmt!": "tsfmt --useTsfmt config/tsfmt.json -r app/**/*.ts test/**/*.ts"
@@ -97,6 +99,8 @@
   ],
   "homepage": "https://witnet.io",
   "devDependencies": {
+    "@commitlint/cli": "^6.2.0",
+    "@commitlint/config-conventional": "^6.1.3",
     "@types/enzyme": "^3.1.1",
     "@types/history": "^4.5.2",
     "@types/jest": "^22.2.3",
@@ -166,6 +170,7 @@
     "webpack-merge": "^4.1.2"
   },
   "dependencies": {
+    "commitlint": "^6.2.0",
     "electron-debug": "^1.1.0",
     "font-awesome": "^4.7.0",
     "history": "^4.6.1",


### PR DESCRIPTION
- [x] I have read and understood [docs/CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.**

## Why this change is necessary and useful
As suggested by @mariocao and discussed in #63, this PR adds [commitizen][commitizen] to our project. It also adds [commitlinter] to  guarantee that GitHub rejects PRs with commit messages not abiding by our guidelines.

## Implications
All commits should now abide by Angular's [conventional changelog convention][convention].

## Why this PR doesn't include tests
No actual testable code was modified—only configuration files.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
[commitizen]: https://github.com/commitizen/cz-cli
[commitlinter]: https://github.com/marionebl/commitlint
[convention]: https://github.com/conventional-changelog-archived-repos/conventional-changelog-angular/blob/master/convention.md