### PR TITLE
Add check for reading CONTRIBUTING document in PR template

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ Thank you for contributing to sheikah! :)
 the brackets) _before_ filing your PR:**
 
 - [ ] I have read and understood [CODE_OF_CONDUCT][code] document.
+- [ ] I have read and understood [CONTRIBUTING][cont] document.
 - [ ] I have read and understood [docs/styleguide][style] document.
 - [ ] I have included tests for the changes in my PR. If not, I have included a
   rationale for why I haven't.
@@ -18,4 +19,5 @@ the brackets) _before_ filing your PR:**
 [Please explain **in detail** why the changes in this PR are needed.]
 
 [code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
+[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
 [style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [docs/styleguide][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt-verify`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Add check for reading CONTRIBUTING document in PR template, just like the above checks do everytime a new pull request is created.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
