### PR TITLE
add contributing guide for signing commits

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Unsure where to begin contributing? You can start by looking through these good 
 * Trim all lines in your commit message to 72 characters
 * Do not include issue numbers in the first line of your commit message
 * Reference issues and pull requests liberally after the first line
+* [Verify your commits][signing-commits] before creating a pull request
 
     A good rule of thumb is that your commit message follows these rules if you can prefix it with "This commit will ..." and it makes sense.
 
@@ -107,6 +108,7 @@ These guidelines are based on the [AragonJS contributing guidelines][aragonjs], 
 [gitter]: https://gitter.im/witnet/sheikah
 [issues]: https://github.com/witnet/sheikah/issues
 [code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
+[signing-commits]: https://help.github.com/articles/signing-commits-with-gpg/
 [styleguide]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
 [first-issue]: https://github.com/witnet/sheikah/labels/good%20first%20issue
 [aragonjs]: https://wiki.aragon.one/submodules/aragon.js/CONTRIBUTING/


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Commits verification is needed while merging a PR, but missed in contributing guide.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
