### PR TITLE
fix(tsconfig): fix output directory in tsconfig.json

### DIFF
--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -25,7 +25,7 @@
 
     "sourceMap": true,
 
-    "outDir": "dist"
+    "outDir": "../dist"
   },
   "files": [
     "../app/index.tsx"
@@ -39,6 +39,6 @@
     "../typings/**/*.d.ts"
   ],
   "exclude": [
-    "dist"
+    "../dist"
   ]
 }


### PR DESCRIPTION
fix #97

# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
Should this not be fixed, results of compilation process would be placed inside config directory, which may be not the right place for them to be. No tests needed, it is just a path fix in a configuration file.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
