### PR TITLE
docs(contributing): add commit message standardization

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -96,7 +96,7 @@ Unsure where to begin contributing? You can start by looking through these good 
 * Standardize your commits:
     - use `yarn commit` to write the commit message with the interactive guide
     - then check the message with `yarn commitmsg`
-    - clean up the problem/warnings from check before push your commits
+    - clean up the problem/warnings from check before pushing your commits
 
     A good rule of thumb is that your commit message follows these rules if you can prefix it with "This commit will ..." and it makes sense.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -93,6 +93,10 @@ Unsure where to begin contributing? You can start by looking through these good 
 * Do not include issue numbers in the first line of your commit message
 * Reference issues and pull requests liberally after the first line
 * [Verify your commits][signing-commits] before creating a pull request
+* Standardize your commits:
+    - use `yarn commit` to write the commit message with the interactive guide
+    - then check the message with `yarn commitmsg`
+    - clean up the problem/warnings from check before push your commits
 
     A good rule of thumb is that your commit message follows these rules if you can prefix it with "This commit will ..." and it makes sense.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -95,7 +95,6 @@ Unsure where to begin contributing? You can start by looking through these good 
 * [Verify your commits][signing-commits] before creating a pull request
 * Standardize your commits:
     - use `yarn commit` to write the commit message with the interactive guide
-    - then check the message with `yarn commitmsg`
     - clean up the problem/warnings from check before pushing your commits
 
     A good rule of thumb is that your commit message follows these rules if you can prefix it with "This commit will ..." and it makes sense.


### PR DESCRIPTION

fix #87


- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**


[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
