### PR TITLE
build(npm): fix tslint command in lint-staged hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "lint-staged": {
     "*.ts": [
-      "tslint -p config"
+      "tslint"
     ]
   },
   "build": {


### PR DESCRIPTION
the command was looking for tsconfig.json in the config directory, and
we moved it back to the root a few commits ago.

# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Fix tslint command that runs as part of `tslint-staged` task.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
