### PR TITLE
Lint travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,11 @@ before_script:
 
 script:
 - node --version
-- yarn package
-- yarn fmt-verify
-- yarn test
-- yarn test-e2e
 - commitlint-travis
+- yarn lint
+- yarn fmt-verify
+- yarn test-all
+- yarn package
 
 after_script: greenkeeper-lockfile-upload
 

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "ts-jest": "^22.4.6",
     "ts-loader": "^4.3.1",
     "ts-node": "^6.0.1",
-    "tslint": "^5.9.1",
+    "tslint": "^5.10.0",
     "typescript": "^2.8.3",
     "typescript-formatter": "^7.2.0",
     "ui-component-loader": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10835,7 +10835,7 @@ tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
 
-tslint@^5.9.1:
+tslint@^5.10.0:
   version "5.10.0"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.10.0.tgz#11e26bccb88afa02dd0d9956cae3d4540b5f54c3"
   dependencies:


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Some rules in tslint require *type checking* (aka: pass the tsconfig path option to tslint) in order to work, see palantir/tslint#2933. Problem is that Codacy/Hound don't support passing that flag to tslint so basically, some rules are not being check in those services. This PR adds a new step to travis to lint the project including these rules that need type checking.

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
