### PR TITLE
fix(crypto): expression comparing buffer is always false

### DIFF
--- a/app/lib/crypto/key/privateKey.ts
+++ b/app/lib/crypto/key/privateKey.ts
@@ -81,7 +81,7 @@ const deriveChildKey = (
   assert(p.cmp(SECP256K1_N) <= 0, Errors.PRIVATE_KEY_POINT_OUT_OF_RANGE)
   // ki = parse256(IL) + kpar (mod n)
   const keyBytes = privateKeyTweakAdd(parentKey.key.bytes, IL)
-  if (keyBytes === null) {
+  if (keyBytes.every(b => b === 0)) {
     // In case ki == 0, proceed with the next value for i
     return deriveChildKey(parentKey, childIndex + 1)
   }

--- a/app/lib/crypto/key/publicKey.ts
+++ b/app/lib/crypto/key/publicKey.ts
@@ -77,7 +77,7 @@ const deriveChildKey = (parentKey: ExtendedKey<PublicKey>,
   //    = G*IL + Kpar
   const Ki = publicKeyTweakAdd(parentKey.key.bytes, IL)
 
-  if (Ki === null) {
+  if (Ki.every(b => b === 0)) {
     // In case Ki is the point at infinity, proceed with the next value for i
     return deriveChildKey(parentKey, childIndex + 1)
   }


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**