### PR TITLE
build(tsconfig): make the ts compiler use 'es2018' instead of 'es6'

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react",
     "lib": [
       "dom",
-      "es6",
+      "es2018",
       "dom.iterable",
       "scripthost"
     ],


### PR DESCRIPTION
# PR Prelude

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

As explained at #134, we should use `es2018` in the TypeScript compiler to benefit from the modern Javascript kool-aid.

No tests as no app code has been modified.

fixes #134

[code]: https://github.com/witnet/sheikah/blob/master/docs/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/docs/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
