### PR TITLE
refactor(address): remove unnecessary switch statement

### DIFF
--- a/app/lib/utils/utils.ts
+++ b/app/lib/utils/utils.ts
@@ -1,0 +1,19 @@
+type stringToNumber = { [key: string]: number }
+type numberToString = { [key: number]: string }
+type stringToString = { [key: string]: string }
+
+/**
+ * Swap keys for values
+ * @param {numberToString} obj
+ * @returns {stringToNumber}
+ */
+export function kvSwap(obj: numberToString): stringToNumber
+export function kvSwap(obj: stringToNumber): numberToString
+export function kvSwap(obj: stringToString): stringToString
+export function kvSwap(obj: stringToNumber | numberToString | stringToString): any {
+  return Object
+    .entries(obj)
+    .reduce((acc, [key, value]) => {
+      return {...acc, [value]: key}
+    }, {})
+}

--- a/test/app/lib/utils/utils.spec.ts
+++ b/test/app/lib/utils/utils.spec.ts
@@ -1,0 +1,15 @@
+import {kvSwap} from "../../../../app/lib/utils/utils"
+import {ChainType} from "../../../../app/lib/chain/chainType"
+
+describe("Utils", () => {
+  const prefixToChainType = {
+    wit: ChainType.main,
+    twit: ChainType.test
+  }
+
+  it("swap keys with values", () => {
+    const swapped = kvSwap(prefixToChainType)
+    expect(swapped[ChainType.main]).toEqual("wit")
+    expect(swapped[ChainType.test]).toEqual("twit")
+  })
+})


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [docs/styleguide][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

As suggested by @aesedepece added a method to swap keys for values and replaced an unnecessarily long switch statement using a call to kvSwap