### PR TITLE
fix: fix app.html not found when running yarn dev

### DIFF
--- a/app/main/index.js
+++ b/app/main/index.js
@@ -1,8 +1,14 @@
 const { app, BrowserWindow, Menu, shell } = require('electron');
+const path = require('path'); // eslint-disable-line
+const paths = require('../../config/paths')
 
 let menu;
 let template;
 let mainWindow = null;
+
+const appHtml = process.env.HOT ?
+      `file://${paths.templateAppHtml}` :
+      `file://${paths.filenameAppHtml}`;
 
 if (process.env.NODE_ENV === 'production') {
   const sourceMapSupport = require('source-map-support'); // eslint-disable-line
@@ -11,7 +17,6 @@ if (process.env.NODE_ENV === 'production') {
 
 if (process.env.NODE_ENV === 'development') {
   require('electron-debug')(); // eslint-disable-line global-require
-  const path = require('path'); // eslint-disable-line
   const p = path.join(__dirname, '..', 'app', 'node_modules'); // eslint-disable-line
   require('module').globalPaths.push(p); // eslint-disable-line
 }
@@ -45,7 +50,7 @@ app.on('ready', () =>
     height: 728
   });
 
-  mainWindow.loadURL(`file://${__dirname}/app.html`);
+    mainWindow.loadURL(appHtml);
 
   mainWindow.webContents.on('did-finish-load', () => {
     mainWindow.show();

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,0 +1,6 @@
+const path = require("path")
+
+module.exports = {
+  templateAppHtml: path.resolve(__dirname, "../app/renderer/ui/app.html"),
+  filenameAppHtml: path.resolve(__dirname, "../dist/app.html")
+}

--- a/config/webpack.renderer.js
+++ b/config/webpack.renderer.js
@@ -11,6 +11,8 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const port = process.env.PORT || 3000;
 const forProduction = process.env.NODE_ENV === "production";
 
+const paths = require("./paths");
+
 const bundleFilename = "bundle.js";
 const styleFilename = "style.css";
 
@@ -141,8 +143,8 @@ const baseConfig = {
     }),
 
     new HtmlWebpackPlugin({
-      filename: path.resolve(__dirname, "../dist/app.html"),
-      template: path.resolve(__dirname, "../app/renderer/ui/app.html"),
+      filename: paths.filenameAppHtml,
+      template: paths.templateAppHtml,
       inject: false,
       bundleFilename,
       styleFilename

--- a/server.js
+++ b/server.js
@@ -18,7 +18,6 @@ const compiler = webpack(webpackRenderer);
 const PORT = process.env.PORT || 3000;
 
 const wdm = webpackDevMiddleware(compiler, {
-  writeToDisk: true,
   publicPath: webpackRenderer.output.publicPath,
   stats: {
     colors: true


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt-verify`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

when running yarn dev the Electron app was complaining that app.html could not be found, the reason
was that yarn dev uses the hot-server which doesn't emit the build files (with the writeToDisk:
true, it only emits the files after stopping the server which is too late) so the solution is to
detect in main/index.js if the app is running in HOT mode in which case it looks for app.html in the
original place rather than in the dist directory

#168 

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
