### PR TITLE
build(scssfmt): add sass formatter

### DIFF
--- a/app/renderer/ui/components/signup/style.scss
+++ b/app/renderer/ui/components/signup/style.scss
@@ -4,7 +4,7 @@
   .centered {
     grid-column-start: 2;
     grid-row-start: 2;
-   }
+  }
 
   .layout {
     background: $grey-light;

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "precommit": "lint-staged",
     "commitmsg": "commitlint -g config/commitlint.config.js -e $GIT_PARAMS",
     "fmt-verify": "tsfmt --useTsfmt config/tsfmt.json --verify app/**/**/*.ts test/**/*.ts",
-    "fmt": "tsfmt --useTsfmt config/tsfmt.json app/**/**/*.ts test/**/*.ts",
-    "fmt!": "tsfmt --useTsfmt config/tsfmt.json -r app/**/**/*.ts test/**/*.ts"
+    "fmt": "tsfmt --useTsfmt config/tsfmt.json app/**/**/*.ts test/**/*.ts && scssfmt --recursive './app/**/**/*.scss' --diff",
+    "fmt!": "tsfmt --useTsfmt config/tsfmt.json -r app/**/**/*.ts test/**/*.ts && scssfmt --recursive './app/**/**/*.scss'"
   },
   "lint-staged": {
     "*.ts": [
@@ -174,6 +174,7 @@
     "rimraf": "^2.6.2",
     "sass-lint": "^1.12.1",
     "sass-loader": "^7.0.1",
+    "scssfmt": "^1.0.6",
     "sinon": "^4.5.0",
     "spectron": "^3.8.0",
     "style-loader": "^0.21.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2396,7 +2396,7 @@ chalk@2.3.1:
     escape-string-regexp "^1.0.5"
     supports-color "^5.2.0"
 
-chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.3.2, chalk@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
@@ -8595,6 +8595,12 @@ postcss-reduce-transforms@^1.0.3:
     postcss "^5.0.8"
     postcss-value-parser "^3.0.1"
 
+postcss-scss@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-1.0.5.tgz#40a10cfd03766accf0a3cf8e65a8af887b2bf6c4"
+  dependencies:
+    postcss "^6.0.21"
+
 postcss-selector-parser@^2.0.0, postcss-selector-parser@^2.2.2:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz#f9437788606c3c9acee16ffe8d8b16297f27bb90"
@@ -8641,7 +8647,7 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.1, postcss@^6.0.2:
+postcss@^6.0.1, postcss@^6.0.19, postcss@^6.0.2, postcss@^6.0.21:
   version "6.0.22"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.22.tgz#e23b78314905c3b90cbd61702121e7a78848f2a3"
   dependencies:
@@ -10128,6 +10134,19 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+scssfmt@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/scssfmt/-/scssfmt-1.0.6.tgz#91c6e0bce5092d6f7a69d9773acd17eac626d2bb"
+  dependencies:
+    chalk "^2.3.2"
+    chokidar "^2.0.2"
+    diff "^3.5.0"
+    globby "^8.0.1"
+    minimist "^1.2.0"
+    postcss "^6.0.19"
+    postcss-scss "^1.0.4"
+    stdin "^0.0.1"
+
 secp256k1@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.5.0.tgz#677d3b8a8e04e1a5fa381a1ae437c54207b738d0"
@@ -10597,6 +10616,10 @@ static-extend@^0.1.1:
 statuses@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
+
+stdin@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/stdin/-/stdin-0.0.1.tgz#d3041981aaec3dfdbc77a1b38d6372e38f5fb71e"
 
 stdout-stream@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This change adds a simple sass formatter in order to harmonize the format of the scss files.
No tests were required because it only adds a new dependency for the formatter.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
