### PR TITLE
fix(yarn start): port fix for appHtml not found to main/index.ts

### DIFF
--- a/app/common/env.ts
+++ b/app/common/env.ts
@@ -1,3 +1,5 @@
 export const inDevelopment: boolean = process.env.NODE_ENV === "development"
 
 export const inDarwin: boolean = process.platform === "darwin"
+
+export const inHotMode: boolean = "HOT" in process.env

--- a/app/main/ui.ts
+++ b/app/main/ui.ts
@@ -1,5 +1,5 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions, shell } from "electron"
-import {inDevelopment, inDarwin} from "app/common/env"
+import { inDevelopment, inHotMode, inDarwin } from "app/common/env"
 
 let menu: Menu
 let template: Array<MenuItemConstructorOptions>
@@ -15,7 +15,11 @@ export function createMainWindow() {
     height: 728
   })
 
-  mainWindow.loadURL(`file://${__dirname}/app.html`)
+  const paths = require("app/../config/paths")
+  const appHtml = inHotMode ?
+    `file://${paths.templateAppHtml}` :
+    `file://${paths.filenameAppHtml}`
+  mainWindow.loadURL(appHtml)
 
   mainWindow.webContents.on("did-finish-load", () => {
     if (mainWindow) {

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,6 +1,7 @@
 const path = require("path")
 
-module.exports = {
-  templateAppHtml: path.resolve(__dirname, "../app/renderer/ui/app.html"),
-  filenameAppHtml: path.resolve(__dirname, "../dist/app.html")
-}
+/** @type {string} */
+module.exports.templateAppHtml = path.resolve(__dirname, "../app/renderer/ui/app.html")
+
+/** @type {string} */
+module.exports.filenameAppHtml = path.resolve(__dirname, "../dist/app.html")

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "cross-env NODE_ENV=production yarn build-main && cross-env NODE_ENV=production yarn build-renderer",
     "build-dev": "cross-env NODE_ENV=development yarn build-main && cross-env NODE_ENV=development yarn build-renderer",
     "dev": "yarn build-main && yarn hot-server -- --exec 'HOT=1 yarn start-electron'",
+    "prestart": "yarn clean",
     "start": "yarn dev",
     "start-electron": "electron ./dist/main",
     "package": "yarn build && build --publish never",


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt-verify`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

This fixes (again) a problem María detected when running `yarn start`. This was fixed #169 but was applied to the `main/index.js`, and since #180 that file no longer exists and has been replaced by `main/index.ts`

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
