### PR TITLE
feat(subsystems): add PlainCipher

### DIFF
--- a/app/main/ciphers/plain.ts
+++ b/app/main/ciphers/plain.ts
@@ -1,0 +1,28 @@
+import Cipher from "./index"
+
+/**
+ * An identity async function returns a Promise that resolves to the input data.
+ * @param data
+ */
+type IdentityAsyncFunction = {
+  <T>(data: T): Promise<T>
+}
+
+/**
+ * Cipher implementation for no encryption.
+ * Yes, this is just a dummy pass through that safely works over any type.
+ */
+export class PlainCipher<T> implements Cipher<T, T> {
+
+  /**
+   * Dummy encrypt method that returns a promise that resolves to the input data.
+   * @param data
+   */
+  public encrypt: IdentityAsyncFunction = async (data) => data
+
+  /**
+   * Dummy decrypt method that returns a promise that resolves to the input data.
+   * @param data
+   */
+  public decrypt: IdentityAsyncFunction = async (data) => data
+}


### PR DESCRIPTION
Cipher implementation for no encryption.

Yes, this is just a dummy pass through that safely works over any type.

All storages must use a `Serializer`, a `Cipher` and a `Persister`. This  will be used by the general app settings persistent storage, which is unencrypted. 

No tests included for obvious reasons :rofl:

fix #183