### PR TITLE
feat(subsystems): add NoHasher

### DIFF
--- a/app/main/ciphers/plain.ts
+++ b/app/main/ciphers/plain.ts
@@ -1,0 +1,28 @@
+import Cipher from "./index"
+
+/**
+ * An identity async function returns a Promise that resolves to the input data.
+ * @param data
+ */
+type IdentityAsyncFunction = {
+  <T>(data: T): Promise<T>
+}
+
+/**
+ * Cipher implementation for no encryption.
+ * Yes, this is just a dummy pass through that safely works over any type.
+ */
+export class PlainCipher<T> implements Cipher<T, T> {
+
+  /**
+   * Dummy encrypt method that returns a promise that resolves to the input data.
+   * @param data
+   */
+  public encrypt: IdentityAsyncFunction = async (data) => data
+
+  /**
+   * Dummy decrypt method that returns a promise that resolves to the input data.
+   * @param data
+   */
+  public decrypt: IdentityAsyncFunction = async (data) => data
+}

--- a/app/main/hashers/no.ts
+++ b/app/main/hashers/no.ts
@@ -1,0 +1,8 @@
+/**
+ * Hasher implementation that performs no actual hashing on input data.
+ * Yes, this is just a dummy pass through that safely works over any type.
+ * @param data
+ */
+export async function noHasher<T>(data: T): Promise<T> {
+  return data
+}


### PR DESCRIPTION
 Hasher implementation that performs no actual hashing on input data.

 Yes, this is just a dummy pass through that safely works over any type.

All storages must use a Serializer, a Cipher, a Persister and a Hasher. Hash functions are used to enhance privacy and make all keys uniform.

No tests included for obvious reasons :rofl:

Fix #199 