### PR TITLE
feat(ipc-renderer): stateless ipc client

### DIFF
--- a/app/common/ipc.ts
+++ b/app/common/ipc.ts
@@ -1,7 +1,3 @@
 export const asyncChannel = "async-msg"
 export const syncChannel = "sync-msg"
-
-export type Ipc<L> = {
-  on(channel: string, listener: L): void;
-  removeAllListeners(channel: string): void;
-}
+export const deadLetterChannel = "deadletter-msg"

--- a/app/common/serializers/json.ts
+++ b/app/common/serializers/json.ts
@@ -5,7 +5,7 @@ import { Serializer } from "./types"
  * by Javascript's own JSON library.
  */
 export type JsonSerializable =
-  number | string | boolean | JsonSerializableObject | JsonSerializableArray
+  null | number | string | boolean | JsonSerializableObject | JsonSerializableArray
 export type JsonSerializableObject = { [key: string]: JsonSerializable }
 export interface JsonSerializableArray extends Array<JsonSerializable> { }
 

--- a/app/main/api/handlers/echo.ts
+++ b/app/main/api/handlers/echo.ts
@@ -1,0 +1,8 @@
+/**
+ * Echo handler
+ */
+async function echo(system: any, params: Array<any>) {
+  return `I got: ${params.join(", ")}`
+}
+
+export default echo

--- a/app/main/api/handlers/error.ts
+++ b/app/main/api/handlers/error.ts
@@ -1,0 +1,8 @@
+/**
+ * Error handler that always
+ */
+async function error(system: any, params: any) {
+  throw new Error(`Error handler throwed this.`)
+}
+
+export default error

--- a/app/main/api/handlers/index.ts
+++ b/app/main/api/handlers/index.ts
@@ -1,4 +1,8 @@
+import { JsonSerializable } from "app/common/serializers"
 export { default as ping } from "./ping"
 export { default as nop } from "./nop"
+export { default as echo } from "./echo"
+export { default as error } from "./error"
 
-export type Handler<T> = (system: T, data: any) => Promise<any>
+export type Handler<T> =
+  (system: T, params: Array<JsonSerializable>) => Promise<JsonSerializable | void>

--- a/app/main/api/handlers/nop.ts
+++ b/app/main/api/handlers/nop.ts
@@ -1,10 +1,10 @@
+import log from "app/common/logging"
+
 /**
- * Handler of no response handler function
- * @param data
- * @returns {Promise<string>}
+ * Void handler
  */
-async function nop(system: any, data: any) {
-  return ""
+async function nop(system: any, params: Array<any>) {
+  log.info(`[NOP Handler] Ignoring message: ${params.join(", ")}`)
 }
 
 export default nop

--- a/app/main/api/handlers/ping.ts
+++ b/app/main/api/handlers/ping.ts
@@ -1,9 +1,7 @@
 /**
- * Handler of ping method
- * @param data
- * @returns {Promise<string>}
+ * Ping handler
  */
-async function ping(system: any, data: any) {
+async function ping(system: any, params: any) {
   return "pong"
 }
 

--- a/app/main/api/routes.ts
+++ b/app/main/api/routes.ts
@@ -1,12 +1,15 @@
 import * as h from "./handlers"
+import { System } from "app/main/system"
 
 export type Routes<T> = {
   [key: string]: h.Handler<T>
 }
 
-export const routes: Routes<any> = {
+export const routes: Routes<System> = {
   ping: h.ping,
-  nop: h.nop
+  nop: h.nop,
+  echo: h.echo,
+  error: h.error
 }
 
 /**

--- a/app/main/crypto/keyPath.ts
+++ b/app/main/crypto/keyPath.ts
@@ -43,7 +43,9 @@ export const fromString = (path: string): KeyPath => {
 /** Key path to string */
 export const toString = (path: KeyPath) => {
   // return _.map(path, childNumberToString).reduce((a, b) => `${a}/${b}`, "m")
-  return ["m", ...path].map(childNumberToString).join("/")
+  const stringPath = path.map(childNumberToString).join("/")
+
+  return `m/${stringPath}`
 }
 
 /**

--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -1,10 +1,10 @@
 const { app, ipcMain } = require("electron")
 
-import {inDevelopment, inDarwin} from "app/common/env"
-import {config} from "app/common/config"
-import {asyncChannel, syncChannel} from "app/common/ipc"
-import {Channels} from "app/main/ipc"
-import {appSystem} from "./system"
+import { inDevelopment, inDarwin } from "app/common/env"
+import { config } from "app/common/config"
+import { asyncChannel, syncChannel, deadLetterChannel } from "app/common/ipc"
+import { Channels } from "app/main/ipc"
+import { appSystem } from "./system"
 import * as api from "./api"
 import * as ui from "./ui"
 import * as ipc from "./ipc"
@@ -43,7 +43,8 @@ async function startApplication() {
   ])
   channels = [
     [asyncChannel, api.asyncListenerFactory(system, api.routes)],
-    [syncChannel, api.syncListenerFactory(system, api.routes)]
+    [syncChannel, api.syncListenerFactory(system, api.routes)],
+    [deadLetterChannel, api.deadLetterListener]
   ]
   ipc.createChannels(ipcMain, channels)
   ui.createMainWindow()

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -1,7 +1,25 @@
-import {Ipc} from "app/common/ipc"
-import {Event} from "./synthetic"
+import log from "app/common/logging"
+import { Event } from "./synthetic"
+export * from "app/common/ipc"
 
+/**
+ * Listener type specific to Electron's main-process.
+ */
 export type Listener = (e: Event, message: string) => Promise<void>
+
+/**
+ * Ipc interface type for Electron's main-proces that is specific
+ * about which methods are actually used in the backend application.
+ */
+export type Ipc = {
+  on(channel: string, listener: Listener): void
+  removeAllListeners(channel: string): void
+}
+
+/**
+ * Channels is an array of tuples where is tuple contains the name of a channel and a listener
+ * function that should be bound to that channel.
+ */
 export type Channels = Array<[string, Listener]>
 
 /**
@@ -11,8 +29,9 @@ export type Channels = Array<[string, Listener]>
  * @param {Channels} channels The collection of channel/listener tuples to wire together.
  * @returns {void} Function used only for side-effects.
  */
-export function createChannels(ipc: Ipc<Listener>, channels: Channels) {
+export function createChannels(ipc: Ipc, channels: Channels) {
   channels.forEach(([channel, listener]) => {
+    log.debug(`[IPC Main] Binding listener to channel ${channel}`)
     ipc.on(channel, listener)
   })
 }
@@ -24,8 +43,9 @@ export function createChannels(ipc: Ipc<Listener>, channels: Channels) {
  * @param {Channels} channels The collection of channel/listener tuples to wire together.
  * @returns {void} Function used only for side-effects.
  */
-export function removeChannels(ipc: Ipc<Listener>, channels: Array<string>) {
+export function removeChannels(ipc: Ipc, channels: Array<string>) {
   channels.forEach((channel) => {
+    log.debug(`[IPC Main] Unbinding listener from channel ${channel}`)
     ipc.removeAllListeners(channel)
   })
 }

--- a/app/main/system.ts
+++ b/app/main/system.ts
@@ -1,24 +1,24 @@
 import * as serializers from "app/common/serializers"
 import * as components from "app/main/subsystems"
 import log from "app/common/logging"
-import {Config} from "app/common/config"
-import {Lifecycle} from "./lifecycle"
+import { Config } from "app/common/config"
+import { Lifecycle } from "./lifecycle"
 
 export type Json = { json: serializers.JsonSerializer }
 
 /**
  * A type representing all the values returned when the system starts.
  */
-export type Values = Json
+export type System = Json
 
 /**
  * Application wide system that starts all its components when started.
  * A system is just stateful object that supports Lifecycle protocol (it can be started and stopped)
- * and returns a map of type `Values` that can be used as a global repository of services needed by
+ * and returns a map of type `System` that can be used as a global repository of services needed by
  * other parts of the application. Any part of the application can explicitly ask for all the
- * `Values` or just a subset of it, e.g.: `Json & Db`.
+ * `System` or just a subset of it, e.g.: `Json & Db`.
  */
-export const appSystem: Lifecycle<Values, Partial<Config>> = {
+export const appSystem: Lifecycle<System, Partial<Config>> = {
   async start(config?: Partial<Config>) {
     log.info("Starting system...")
     const [json] = await Promise.all([

--- a/app/renderer/api.ts
+++ b/app/renderer/api.ts
@@ -1,0 +1,134 @@
+/* tslint:disable:no-null-keyword */
+/**
+ * This module exports the `Client` class which is used to interact via ipc with Electron main
+ * process.
+ */
+import log from "app/common/logging"
+import * as protocol from "app/common/ipc-protocol"
+import * as ipc from "./ipc"
+import { jsonSerializer, JsonSerializer } from "app/common/serializers"
+
+/** Options type expected by `Client` */
+export type Options = {
+  /** Channel name used by the client to send requests/notifications */
+  channel: string
+  /** IPC backend used by the client to send requests and to listen for responses  */
+  ipc: ipc.Ipc
+  /** Timeout in milliseconds to wait for a response */
+  timeout: number
+  /** Generator of request ids used by the client */
+  idGen: ipc.RequestIdGenerator
+  /** Function that handles the message deserialization and interpretation */
+  messageHandler: (json: JsonSerializer, message: string) => Promise<any>
+  /** Json serializer to use for (de)serializing requests/responses */
+  json: JsonSerializer
+}
+
+/** ApiClient interface that concrete api clients must implement */
+export interface ApiClient {
+  withOptions(opts: Partial<Options>): ApiClient
+  notify(method: string, ...args: Array<any>): void
+  request(method: string, ...args: Array<any>): Promise<any>
+}
+
+/** Default `Client` options */
+export const defaultOptions: Options = {
+  channel: ipc.asyncChannel,
+  timeout: ipc.timeout,
+  ipc: ipc.electronIpc,
+  idGen: ipc.idGenerator,
+  messageHandler: defaultMessageHandler,
+  json: jsonSerializer
+}
+
+/**
+ * Default message handler used in Api Client's `defaultOptions`. This handler is the one processing
+ * response messages from Electron's IPC Main process.
+ */
+export async function defaultMessageHandler(json: JsonSerializer, message: string): Promise<any> {
+  try {
+    const obj = await json.deserialize(message)
+    const response = await protocol.decodeResponse(obj)
+    if ("error" in response) {
+      throw new Error(response.error.message)
+    }
+
+    return response.result
+  } catch (e) {
+    throw e
+  }
+}
+
+/**
+ * Class representing the Api Client used to send requests and notifications using the JSON-RPC
+ * protocol to Electron's IPC Main process.
+ */
+export class Client implements ApiClient {
+  constructor(public options: Options = defaultOptions) { }
+
+  /** Returns a new client with its options overriden by `newOpts`. */
+  public withOptions(newOpts: Partial<Options>): Client {
+    return new Client({ ...this.options, ...newOpts })
+  }
+
+  /**
+   * Invokes `method` asynchronously in IPC Main process as a notification.
+   * Notifications are like requests but they don't expect any response.
+   * This function will always return a resolved Promise with the `undefined`
+   * value in case of success, or a rejected Promise in case of any error in
+   * preparing the payload of the request.
+   */
+  public async notify(method: string, ...args: Array<any>): Promise<void> {
+    return this.send(method, args).then((result) => undefined)
+  }
+
+  /** Invokes `method` asynchronously in IPC Main process as a request.
+   * This function returns a Promise that will eventually be resolved with the
+   * response of Main or it will reject it with a timeout error in case of
+   * a response doesn't arrive in `ipc.timeout` milliseconds (by default) or if
+   * any error ocurrs preparing the payload of the request.
+   */
+  public async request(method: string, ...args: Array<any>): Promise<any> {
+    return this.send(method, args, this.options.idGen())
+  }
+
+  /** Helper method that contains the common logic for sending requests or notifications. */
+  private async send(method: string, args: Array<any>, id?: string | number): Promise<any> {
+    const { channel, timeout, ipc, json, messageHandler } = this.options
+    const replyChannel = id ? protocol.replyChannel(id) : null
+    const request = id ? protocol.request(method, id, args) : protocol.notification(method, args)
+
+    return new Promise((resolve, reject) => {
+      if (replyChannel) {
+        log.debug(`[IPC Renderer] Client sending request ${request.method} (${replyChannel})`)
+
+        ipc.once(replyChannel, (event: any, message: string) => {
+          log.debug(`[IPC Renderer] Client received response for ${request.method}: ${message}`)
+          messageHandler(json, message).then(resolve).catch(reject)
+        })
+
+        setTimeout(() => {
+          ipc.removeAllListeners(replyChannel)
+          reject(new protocol.TimeoutError(`[IPC Renderer] Client request ${method} timed out`))
+        }, timeout)
+      }
+
+      json
+        .serialize(request)
+        .then((message) => {
+          ipc.send(channel, message)
+        })
+        .then(() => {
+          if (!replyChannel) {
+            resolve()
+          }
+        })
+        .catch((e) => {
+          if (replyChannel) {
+            ipc.removeAllListeners(replyChannel)
+          }
+          reject(e)
+        })
+    })
+  }
+}

--- a/app/renderer/ipc.ts
+++ b/app/renderer/ipc.ts
@@ -1,0 +1,46 @@
+import { ipcRenderer } from "electron"
+export * from "app/common/ipc"
+
+/**
+ * Listener type specific to Electron's renderer-process
+ */
+export type Listener = (e: any, message: string) => void
+
+/**
+ * Ipc interface type for Electron's renderer-proces that is specific
+ * about which methods are actually used in the frontend application.
+ */
+export type Ipc = {
+  once(channel: string, listener: Listener): void
+  send(channel: string, ...args: Array<any>): void
+  sendSync(channel: string, ...args: Array<any>): any
+  removeAllListeners(channel: string): void
+}
+
+/** A default implementation of `Ipc` that is just the one supplied by Electron */
+export const electronIpc: Ipc = ipcRenderer
+
+/** RequestIdGenerator interface */
+export type RequestIdGenerator = () => number | string
+
+/**
+ * Factory function that returns a `RequestIdGenerator` function. This generator is not unique
+ * but it's sequential and its period is `Number.MAX_SAFE_INTEGER` which should be more than
+ * enough for the requirements of this application since having more than `Number.MAX_SAFE_INTEGER`
+ * concurrent requests seems unlikely.
+ */
+export function idGeneratorFactory(): RequestIdGenerator {
+  let current = 0
+
+  return () => {
+    current = (current + 1) % Number.MAX_SAFE_INTEGER
+
+    return current
+  }
+}
+
+/** A default ids generator for requests. */
+export const idGenerator = idGeneratorFactory()
+
+/** A default timeout to be used in IPC */
+export const timeout = 3000

--- a/app/renderer/store/configureStore.development.ts
+++ b/app/renderer/store/configureStore.development.ts
@@ -4,7 +4,6 @@ import { createHashHistory } from "history"
 import { routerMiddleware, push } from "react-router-redux"
 import { createLogger } from "redux-logger"
 import rootReducer from "../reducers"
-
 import * as counterActions from "../actions/counter"
 
 declare const window: Window & {
@@ -56,8 +55,8 @@ const enhancer = composeEnhancers(
 
 export = {
   history,
-  configureStore(initialState: Object | void) {
-    const store = createStore(rootReducer, initialState, enhancer)
+  configureStore(initialState: {} | void) {
+    const store = createStore<{}>(rootReducer, initialState || {}, enhancer)
 
     if (module.hot) {
       module.hot.accept("../reducers", () => {

--- a/app/renderer/store/configureStore.production.ts
+++ b/app/renderer/store/configureStore.production.ts
@@ -10,7 +10,7 @@ const enhancer = applyMiddleware(thunk, router)
 
 export = {
   history,
-  configureStore(initialState: Object | void) {
-    return createStore(rootReducer, initialState, enhancer)
+  configureStore(initialState: {} | void) {
+    return createStore(rootReducer, initialState || {}, enhancer)
   }
 }

--- a/config/tsconfig.json
+++ b/config/tsconfig.json
@@ -15,6 +15,7 @@
 
     "alwaysStrict": true,
     "strictNullChecks": true,
+    "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,
@@ -28,7 +29,8 @@
     "outDir": "dist"
   },
   "files": [
-    "../app/renderer/index.tsx"
+    "../app/renderer/index.tsx",
+    "../app/main/index.ts"
   ],
   "include": [
     "../app/**/*.ts",

--- a/test/__stubs__/ipcRenderer.ts
+++ b/test/__stubs__/ipcRenderer.ts
@@ -1,0 +1,43 @@
+export type Options = {
+  fair: boolean
+}
+
+/**
+ * Factory function for creating IpcRenderer-like objects that support basic
+ * event-listening features and can be used to test behaviours that depend
+ * on this.
+ */
+export function ipcRendererFactory(opts?: Partial<Options>) {
+  const options = {
+    fair: true,
+    ...opts
+  }
+  let currentListener: Function | undefined
+
+  const stub = {
+    listener() {
+      return currentListener
+    },
+    once(chan: string, listener: any) {
+      currentListener = (...args: Array<any>) => {
+        listener(...args)
+        stub.removeAllListeners(chan)
+      }
+    },
+    send(chan: string, message: string) {
+      if (options.fair && currentListener) {
+        currentListener("event", message)
+      }
+    },
+    sendSync(chan: string, message: string) {
+      if (options.fair && currentListener) {
+        currentListener("event", message)
+      }
+    },
+    removeAllListeners(chan: string) {
+      currentListener = undefined
+    }
+  }
+
+  return stub
+}

--- a/test/__stubs__/serializers.ts
+++ b/test/__stubs__/serializers.ts
@@ -1,0 +1,8 @@
+export const jsonSerializer = {
+  async serialize(x: any) {
+    return x
+  },
+  async deserialize(x: any) {
+    return x
+  }
+}

--- a/test/app/common/ipc-protocol.fixtures.ts
+++ b/test/app/common/ipc-protocol.fixtures.ts
@@ -5,8 +5,7 @@ export const requests = {
     { jsonrpc: "2.0", id: null, method: "sum" },
     { jsonrpc: "2.0", id: "123", method: "sum" },
     { jsonrpc: "2.0", id: 123, method: "sum" },
-    { jsonrpc: "2.0", id: 123, method: "sum", params: [1, 2, 3] },
-    { jsonrpc: "2.0", id: 123, method: "sum", params: {a: 1, b: 2, c: 3} }
+    { jsonrpc: "2.0", id: 123, method: "sum", params: [1, 2, 3] }
   ],
 
   invalid: [
@@ -14,15 +13,19 @@ export const requests = {
     { jsonrpc: "3.0", method: "sum" },
     { jsonrpc: "2.0", id: true, method: "sum" },
     { jsonrpc: "2.0", id: 123, method: 123 },
-    { jsonrpc: "2.0", method: "sum", params: "1 2 3" }
+    { jsonrpc: "2.0", method: "sum", params: "1 2 3" },
+    // This is a valid request in JSON-RPC, but since all requests are going to be behind a function
+    // signature wich is translated always into a list of parameters, we are forbidding this type
+    // of requests to make the implementation simpler
+    { jsonrpc: "2.0", id: 123, method: "sum", params: { a: 1, b: 2, c: 3 } }
   ]
 }
 
 export const responses = {
   valid: [
     { jsonrpc: "2.0", id: null, result: null },
-    { jsonrpc: "2.0", id: "123", error: { code: 123, message: "..."} },
-    { jsonrpc: "2.0", id: "123", error: { code: 123, message: "...", data: {}} },
+    { jsonrpc: "2.0", id: "123", error: { code: 123, message: "..." } },
+    { jsonrpc: "2.0", id: "123", error: { code: 123, message: "...", data: {} } },
     { jsonrpc: "2.0", id: 123, result: 123 },
   ],
 
@@ -31,8 +34,8 @@ export const responses = {
     { jsonrpc: "2.0", result: null },
     { jsonrpc: "2.0", id: "123", error: 123 },
     { jsonrpc: "2.0", id: null, error: {} },
-    { jsonrpc: "2.0", id: null, error: { code: "123", message: "..."} },
-    { jsonrpc: "2.0", id: null, error: { code: "123", message: 123} }
+    { jsonrpc: "2.0", id: null, error: { code: "123", message: "..." } },
+    { jsonrpc: "2.0", id: null, error: { code: "123", message: 123 } }
   ]
 }
 
@@ -75,11 +78,11 @@ export const successResponseFactory = [
 
 export const errorResponseFactory = [
   [
-    [{code: 123, message: "error"}, 123],
-    { jsonrpc: "2.0", error: {code: 123, message: "error"}, id: 123 }
+    [{ code: 123, message: "error" }, 123],
+    { jsonrpc: "2.0", error: { code: 123, message: "error" }, id: 123 }
   ],
   [
-    [{code: 123, message: "error", data: {}}, 123],
-    { jsonrpc: "2.0", error: {code: 123, message: "error", data: {}}, id: 123 }
+    [{ code: 123, message: "error", data: {} }, 123],
+    { jsonrpc: "2.0", error: { code: 123, message: "error", data: {} }, id: 123 }
   ]
 ]

--- a/test/app/main/api/index.spec.ts
+++ b/test/app/main/api/index.spec.ts
@@ -1,6 +1,6 @@
+/* tslint:disable:no-null-keyword */
 import * as api from "app/main/api"
-import { asyncChannel } from "app/common/ipc"
-import { InvalidParamsError, ErrCodes } from "app/common/ipc-protocol"
+import { InvalidParamsError, ErrCodes, replyChannel } from "app/common/ipc-protocol"
 import { syntheticEvent } from "test/__stubs__/event"
 
 const system = {
@@ -107,12 +107,12 @@ describe("API", () => {
         const expectedResponse = {
           jsonrpc: "2.0",
           id: "some id",
-          result: undefined
+          result: null
         }
 
         await asyncHandler(event, request)
 
-        expect(senderMock).toBeCalledWith(asyncChannel, expectedResponse)
+        expect(senderMock).toBeCalledWith(replyChannel(expectedResponse.id), expectedResponse)
         expect(handlerMock).toBeCalledWith(system, [1, 2, 3])
       })
     })

--- a/test/app/renderer/api.spec.ts
+++ b/test/app/renderer/api.spec.ts
@@ -1,0 +1,160 @@
+/* tslint:disable:no-string-throw */
+import { jsonSerializer as json } from "app/common/serializers"
+import * as api from "app/renderer/api"
+import { ipcRendererFactory } from "test/__stubs__/ipcRenderer"
+import { jsonSerializer } from "test/__stubs__/serializers"
+
+describe("api", () => {
+  describe("defaultMessageHandler", () => {
+    it("should error if message is not valid Json", async () => {
+      return expect(api.defaultMessageHandler(json, "not valid json")).rejects.toBeTruthy()
+    })
+
+    it("should error if message is not valid Response", async () => {
+      const message = JSON.stringify({
+        someField: "some value"
+      })
+
+      return expect(api.defaultMessageHandler(json, message)).rejects.toBeTruthy()
+    })
+
+    it("should error if response is not successful", async () => {
+      const message = JSON.stringify({
+        jsonrpc: "2.0",
+        id: "123",
+        error: { code: -1, message: "Some error" }
+      })
+
+      return expect(api.defaultMessageHandler(json, message)).rejects.toBeTruthy()
+    })
+
+    it("should succeed if response is successful", async () => {
+      const message = JSON.stringify({
+        jsonrpc: "2.0",
+        id: "123",
+        result: 123
+      })
+
+      return expect(api.defaultMessageHandler(json, message)).resolves.toEqual(123)
+    })
+  })
+
+  describe("client", () => {
+    it("should be created with default options", () => {
+      const client = new api.Client()
+
+      expect(client.options).toBe(api.defaultOptions)
+    })
+
+    it("should let you override options", () => {
+      const client = new api.Client().withOptions({ timeout: 123123 })
+
+      expect(client.options.timeout).toBe(123123)
+    })
+
+    describe("request", () => {
+      const messageHandler = jest.fn()
+      messageHandler.mockResolvedValue("some response")
+
+      const options = {
+        ...api.defaultOptions,
+        timeout: 0,
+        idGen: () => "some generated id",
+        json: jsonSerializer,
+        ipc: ipcRendererFactory(),
+        messageHandler
+      }
+      const client = new api.Client(options)
+
+      it("should send the correct request", async () => {
+        const expected = {
+          jsonrpc: "2.0",
+          id: "some generated id",
+          method: "someMethod",
+          params: [1, 2, 3]
+        }
+        await client.request("someMethod", 1, 2, 3)
+
+        expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
+      })
+
+      it("should timeout if server does not respond in time", async () => {
+        const expected = {
+          message: "[IPC Renderer] Client request someMethod timed out",
+          name: "TimeoutError"
+        }
+        const options = {
+          ipc: ipcRendererFactory({ fair: false })
+        }
+        const timeoutClient = client.withOptions(options)
+
+        const error = await timeoutClient.request("someMethod").catch((e) => e)
+
+        expect(error).toEqual(expected)
+        expect(options.ipc.listener()).toBeUndefined()
+      })
+
+      it("should return value from server", async () => {
+        const response = await client.request("someMethod")
+        expect(response).toBe("some response")
+      })
+
+      it("should cleanup listeners on success", async () => {
+        await client.request("someMethod")
+        expect(options.ipc.listener()).toBeUndefined()
+      })
+
+      it("should cleanup listeners on error", async () => {
+        const errorClient = client.withOptions({
+          json: {
+            ...jsonSerializer,
+            async serialize(x: any) {
+              throw "kaboom!"
+            }
+          }
+        })
+
+        const error = await errorClient.request("someMethod").catch((e) => e)
+
+        expect(error).toBe("kaboom!")
+        expect(options.ipc.listener()).toBeUndefined()
+      })
+    })
+
+    describe("notify", () => {
+      const messageHandler = jest.fn()
+      messageHandler.mockResolvedValue(undefined)
+
+      const options = {
+        ...api.defaultOptions,
+        timeout: 0,
+        idGen: () => "some generated id",
+        json: jsonSerializer,
+        ipc: ipcRendererFactory(),
+        messageHandler
+      }
+      const client = new api.Client(options)
+
+      it("should send the correct notification", async () => {
+        const expected = {
+          jsonrpc: "2.0",
+          method: "someMethod",
+          params: [1, 2, 3]
+        }
+        const clientWithHandler = client.withOptions({
+          ipc: ipcRendererFactory()
+        })
+        clientWithHandler.options.ipc.once("chan", messageHandler)
+        await clientWithHandler.notify("someMethod", 1, 2, 3)
+
+        expect(messageHandler).toBeCalledWith("event", expected)
+      })
+
+      it("should not wait for a response", async () => {
+        await client.notify("someMethod")
+
+        expect(options.ipc.listener()).toBeUndefined()
+      })
+    })
+  })
+})

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,6 +1,9 @@
+const log = require("electron-log")
 const Adapter = require('enzyme-adapter-react-16')
 const { configure } = require('enzyme')
 require('jest-enzyme')
+
+log.transports.console.level = log.transports.file.level = "error"
 
 configure({
   adapter: new Adapter()


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt-verify`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

add an ipc client to be used to interact with handlers defined in Electron's Main process.

this client follows a **stateless design**, that is, on sending a request the client will bound once to a special and unique "reply channel" that will be used by the Main process to univocally send the response for that request. if there's any problem parsing or decoding the request, the response will be sent to an special "dead letter" channel, is responsability of the frontend (not the client) to subscribe to that channel in order to be notified of invalid requests that are not being processed correctly (by default there's a listener in IPC Main that logs all messages received in dead letter channel).

the client also supports "notifications", that is, requests that do not wait for a response.

example:

```typescript
import { Client } from "app/renderer/api"

const client = new Client()

client.request("echo", "this", "are", "parameters")
  .then(processResult)
  .catch(processErrors)

client.notify("echo", "this", "are", "parameters")
  .then(processResult)
  .catch(processErrors)
```

## Troubleshooting

Communication from both sides of IPC is logged as `debug`. Logs are written to `~/.config/Sheikah/log.log`.

Example:

```
[2018-07-02 18:37:44.632] [info] Starting system...
[2018-07-02 18:37:44.656] [info] System started
[2018-07-02 18:37:44.656] [debug] [IPC Main] Binding listener to channel async-msg
[2018-07-02 18:37:44.656] [debug] [IPC Main] Binding listener to channel sync-msg
[2018-07-02 18:38:10.875] [debug] [IPC Renderer] Client sending request echo (async-reply-chan-1)
[2018-07-02 18:38:10.883] [debug] [IPC Main] Received message: {"jsonrpc":"2.0","method":"echo","id":1,"params":[1,2,true,false]}
[2018-07-02 18:38:10.890] [debug] [IPC Main] Created reponse message: {"jsonrpc":"2.0","id":1,"result":"I got: 1, 2, true, false"})
[2018-07-02 18:38:10.890] [debug] [IPC Main] Sending response message (async-reply-chan-1)
[2018-07-02 18:38:10.892] [debug] [IPC Renderer] Client received response for echo: {"jsonrpc":"2.0","id":1,"result":"I got: 1, 2, true, false"}
[2018-07-02 18:38:18.565] [debug] [IPC Renderer] Client sending request error (async-reply-chan-2)
[2018-07-02 18:38:18.565] [debug] [IPC Main] Received message: {"jsonrpc":"2.0","method":"error","id":2,"params":[1,2,true,false]}
[2018-07-02 18:38:18.566] [debug] [IPC Main] Created reponse message: {"jsonrpc":"2.0","id":2,"error":{"data":{"error":{},"message":"{\"jsonrpc\":\"2.0\",\"method\":\"error\",\"id\":2,\"params\":[1,2,true,false]}"},"code":-32603,"message":"Internal JSON-RPC error"}})
[2018-07-02 18:38:18.567] [debug] [IPC Main] Sending response message (async-reply-chan-2)
[2018-07-02 18:38:18.567] [debug] [IPC Renderer] Client received response for error: {"jsonrpc":"2.0","id":2,"error":{"data":{"error":{},"message":"{\"jsonrpc\":\"2.0\",\"method\":\"error\",\"id\":2,\"params\":[1,2,true,false]}"},"code":-32603,"message":"Internal JSON-RPC error"}}
[2018-07-02 18:38:27.575] [debug] [IPC Main] Received message: {"jsonrpc":"2.0","method":"nop","params":[1,2,3]}
[2018-07-02 18:38:27.579] [info] [NOP Handler] Ignoring message: 1,2,3
[2018-07-02 18:38:27.580] [debug] [IPC Main] Created reponse message: {"jsonrpc":"2.0","id":null,"result":null})
[2018-07-02 18:38:27.581] [debug] [IPC Main] Sending response message (deadletter-msg)
[2018-07-02 19:32:43.843] [debug] [IPC Main] Unbinding listener from channel async-msg
[2018-07-02 19:32:43.844] [debug] [IPC Main] Unbinding listener from channel sync-msg
[2018-07-02 19:32:43.846] [info] Stopping system...
[2018-07-02 19:32:43.848] [info] System stopped
```

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
