### PR TITLE
fix(css): prefix antd overrides with app id

### DIFF
--- a/app/renderer/ui/app.global.scss
+++ b/app/renderer/ui/app.global.scss
@@ -5,20 +5,21 @@ body {
   position: relative;
   height: 100vh;
   font-family: Arial, Helvetica, Helvetica Neue, serif;
-}
 
-.ant-card-head {
-  align-items: center;
-  background: linear-gradient(to right, $purple, $blue);
-  color: $white;
-  display: flex;
-  height: 100px;
-}
-.ant-card-head-title {
-  color: $white;
-  font-size: 22px;
-}
+  .ant-card-head {
+    align-items: center;
+    background: linear-gradient(to right, $purple, $blue);
+    color: $white;
+    display: flex;
+    height: 100px;
+  }
 
-.ant-card-body {
-  padding: 0;
+  .ant-card-head-title {
+    color: $white;
+    font-size: 22px;
+  }
+
+  .ant-card-body {
+    padding: 0;
+  }
 }


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt-verify`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

prefix antd overrides with `body` tag so our selectors override antd'sotherwise the opposite happens in the production build because our global styles are injected before antd's

fixes #203

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
