### PR TITLE
feat(api): create new mnemonics

### DIFF
--- a/app/common/runtimeTypes/storage/wallets.ts
+++ b/app/common/runtimeTypes/storage/wallets.ts
@@ -8,3 +8,20 @@ export type WalletInfo = t.TypeOf<typeof WalletInfo>
 
 export const Wallets = t.array(WalletInfo)
 export type Wallets = t.TypeOf<typeof Wallets>
+
+const Mnemonics = t.type({
+  mnemonics: t.string
+})
+
+export const NewMnemonicsResponse = t.exact(Mnemonics)
+export type NewMnemonicsResponse = t.TypeOf<typeof NewMnemonicsResponse>
+
+// UnconsolidatedWallet represents a transient wallet which is being created
+export const UnconsolidatedWallet = t.intersection([
+  Mnemonics,
+  t.partial({
+    id: t.string,
+    caption: t.string
+  })
+])
+export type UnconsolidatedWallet = t.TypeOf<typeof UnconsolidatedWallet>

--- a/app/main/api/handlers/index.ts
+++ b/app/main/api/handlers/index.ts
@@ -5,6 +5,7 @@ export { default as ping } from "./ping"
 export { default as nop } from "./nop"
 export { default as echo } from "./echo"
 export { default as error } from "./error"
+export { default as newMnemonics } from "./newMnemonics"
 
 export type Handler<T> =
   (system: T, params: Array<JsonSerializable>) => Promise<JsonSerializable | void>

--- a/app/main/api/handlers/newMnemonics.ts
+++ b/app/main/api/handlers/newMnemonics.ts
@@ -1,0 +1,20 @@
+import { asObject } from "app/common/runtimeTypes"
+import { SubSystems } from "app/main/system"
+import { generate } from "app/main/crypto/mnemonic"
+import { NewMnemonicsResponse } from "app/common/runtimeTypes/storage/wallets"
+
+/**
+ * Handler function for "newMnemonics" method.
+ * It retrieves and returns a list of mnemonics words.
+ * @param system
+ * @param params
+ */
+export default async function newMnemonics(system: SubSystems, params: any) {
+  // Get mnemonics from crypto library
+  const mnemonicsResponse = { mnemonics: generate() }
+
+  // Update app state with unconsolidated wallet entry
+  system.appStateManager.update({ unconsolidatedWallet: mnemonicsResponse })
+
+  return asObject(mnemonicsResponse, NewMnemonicsResponse)
+}

--- a/app/main/api/handlers/newMnemonics.ts
+++ b/app/main/api/handlers/newMnemonics.ts
@@ -1,7 +1,7 @@
 import { asObject } from "app/common/runtimeTypes"
 import { SubSystems } from "app/main/system"
-import { generate } from "app/main/crypto/mnemonic"
 import { NewMnemonicsResponse } from "app/common/runtimeTypes/storage/wallets"
+import * as mnemonic from "app/main/crypto/mnemonic"
 
 /**
  * Handler function for "newMnemonics" method.
@@ -11,7 +11,7 @@ import { NewMnemonicsResponse } from "app/common/runtimeTypes/storage/wallets"
  */
 export default async function newMnemonics(system: SubSystems, params: any) {
   // Get mnemonics from crypto library
-  const mnemonicsResponse = { mnemonics: generate() }
+  const mnemonicsResponse: NewMnemonicsResponse = { mnemonics: mnemonic.generate() }
 
   // Update app state with unconsolidated wallet entry
   system.appStateManager.update({ unconsolidatedWallet: mnemonicsResponse })

--- a/app/main/api/routes.ts
+++ b/app/main/api/routes.ts
@@ -11,7 +11,8 @@ export const routes: Routes<SubSystems> = {
   ping: h.ping,
   nop: h.nop,
   echo: h.echo,
-  error: h.error
+  error: h.error,
+  newMnemonics: h.newMnemonics
 }
 
 /**

--- a/app/main/appState.ts
+++ b/app/main/appState.ts
@@ -1,5 +1,5 @@
 import { AppInfo } from "app/common/runtimeTypes/storage/app"
-import { Wallets } from "app/common/runtimeTypes/storage/wallets"
+import { Wallets, UnconsolidatedWallet } from "app/common/runtimeTypes/storage/wallets"
 import * as t from "io-ts"
 
 /**
@@ -52,7 +52,8 @@ export const AppState = t.intersection([
     wallets: Wallets,
   }),
   t.partial({
-    appInfo: AppInfo
+    appInfo: AppInfo,
+    unconsolidatedWallet: UnconsolidatedWallet
   })
 ], "AppState")
 export type AppState = t.TypeOf<typeof AppState>

--- a/app/renderer/api/index.ts
+++ b/app/renderer/api/index.ts
@@ -5,8 +5,13 @@
  */
 import log from "app/common/logging"
 import * as protocol from "app/common/ipc-protocol"
-import * as ipc from "./ipc"
+import * as ipc from "app/renderer/ipc"
 import { jsonSerializer, JsonSerializer } from "app/common/serializers"
+
+/**
+ * Exports API renderer functions
+ */
+export { newMnemonics } from "./newMnemonics"
 
 /** Options type expected by `Client` */
 export type Options = {

--- a/app/renderer/api/newMnemonics.ts
+++ b/app/renderer/api/newMnemonics.ts
@@ -1,0 +1,15 @@
+import { Contexts, asRuntimeType } from "app/common/runtimeTypes"
+import { ApiClient } from "app/renderer/api"
+import { NewMnemonicsResponse } from "app/common/runtimeTypes/storage/wallets"
+
+/**
+ * Function to request the creation of new mnemonic words through the API Client
+ * @param client
+ */
+export async function newMnemonics(client: ApiClient): Promise<NewMnemonicsResponse> {
+  // Request the creation of new mnemonics
+  const mnemonicsResponse = await client.request("newMnemonics")
+
+  // Cast return value to a new mnemonics response
+  return asRuntimeType(mnemonicsResponse, NewMnemonicsResponse, Contexts.IPC)
+}

--- a/test/app/main/api/handlers/newMnemonics.spec.ts
+++ b/test/app/main/api/handlers/newMnemonics.spec.ts
@@ -1,0 +1,53 @@
+import {newMnemonics} from "app/main/api/handlers"
+import {asRuntimeType} from "app/common/runtimeTypes"
+import {NewMnemonicsResponse} from "app/common/runtimeTypes/storage/wallets"
+
+describe("NewMnemonics Handler", () => {
+
+  it("should return a non-empty mnemonics as response", async () => {
+    const system = {
+      appStateManager: {
+        update: () => undefined
+      }
+    }
+
+    const result = await newMnemonics(system, {})
+
+    // Check that the return value is an unconsolidated wallet
+    const mnemonicsResponse = asRuntimeType(result, NewMnemonicsResponse)
+
+    // Check that new mnemonic response contains a non-empty string
+    expect(mnemonicsResponse.mnemonics).toBeTruthy()
+  })
+
+  it("should have called the app state manager update function", async () => {
+    const updateMock = jest.fn()
+    const system = {
+      appStateManager: {
+        update: updateMock
+      }
+    }
+
+    // Check that updateMock function has been called once
+    await newMnemonics(system, {})
+    expect(updateMock.mock.calls.length).toBe(1)
+  })
+
+  it("should have called update() with the unconsolidated wallet with mnemonics", async () => {
+    const updateMock = jest.fn()
+    const system = {
+      appStateManager: {
+        update: updateMock
+      }
+    }
+
+    const result = await newMnemonics(system, {})
+
+    // Check that updateMock function has been called with an unconsolidatedWallet as argument
+    expect("unconsolidatedWallet" in updateMock.mock.calls[0][0]).toBeTruthy()
+
+    // Check that updateMock function update was called with the same mnemonics
+    expect(updateMock.mock.calls[0][0].unconsolidatedWallet).toBe(result)
+  })
+
+})

--- a/test/app/main/api/handlers/newMnemonics.spec.ts
+++ b/test/app/main/api/handlers/newMnemonics.spec.ts
@@ -11,9 +11,10 @@ describe("NewMnemonics Handler", () => {
       }
     }
 
+    // Call the new mnemonics handler and wait for the response
     const result = await newMnemonics(system, {})
 
-    // Check that the return value is an unconsolidated wallet
+    // Check that the return value is a new mnemonics response runtime type
     const mnemonicsResponse = asRuntimeType(result, NewMnemonicsResponse)
 
     // Check that new mnemonic response contains a non-empty string
@@ -41,6 +42,7 @@ describe("NewMnemonics Handler", () => {
       }
     }
 
+    // Call the new mnemonics handler and wait for the response
     const result = await newMnemonics(system, {})
 
     // Check that updateMock function has been called with an unconsolidatedWallet as argument

--- a/test/app/renderer/api/newMnemonics.spec.ts
+++ b/test/app/renderer/api/newMnemonics.spec.ts
@@ -1,7 +1,6 @@
-import * as api from "app/renderer/api"
 import {ipcRendererFactory} from "test/__stubs__/ipcRenderer"
 import {jsonSerializer} from "test/__stubs__/serializers"
-import {newMnemonics} from "app/renderer/api/newMnemonics"
+import * as api from "app/renderer/api"
 import {routes} from "app/main/api"
 
 describe("NewMnemonics API", () => {
@@ -21,7 +20,7 @@ describe("NewMnemonics API", () => {
   const client = new api.Client(options)
 
   it("should return valid mnemonics", async () => {
-    const response = await newMnemonics(client)
+    const response = await api.newMnemonics(client)
     expect(response).toMatchObject(mnemonics)
   })
 
@@ -34,7 +33,7 @@ describe("NewMnemonics API", () => {
     }
 
     // Call newMnemonics renderer function to trigger a JSON-RPC request and wait for the response
-    await newMnemonics(client)
+    await api.newMnemonics(client)
 
     // Check that the requested method is in the routes of the main process
     expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)

--- a/test/app/renderer/api/newMnemonics.spec.ts
+++ b/test/app/renderer/api/newMnemonics.spec.ts
@@ -25,7 +25,7 @@ describe("NewMnemonics API", () => {
     expect(response).toMatchObject(mnemonics)
   })
 
-  it("should send a correct routed JSON-RPC request", async () => {
+  it("should send a routable JSON-RPC request", async () => {
     const expected = {
       jsonrpc: "2.0",
       id: "some generated id",
@@ -33,9 +33,10 @@ describe("NewMnemonics API", () => {
       params: []
     }
 
+    // Call newMnemonics renderer function to trigger a JSON-RPC request and wait for the response
     await newMnemonics(client)
 
-    // Check that the request method is in the routes of the main process
+    // Check that the requested method is in the routes of the main process
     expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)
 
     // Check that the message handler function has been called correctly

--- a/test/app/renderer/api/newMnemonics.spec.ts
+++ b/test/app/renderer/api/newMnemonics.spec.ts
@@ -1,0 +1,45 @@
+import * as api from "app/renderer/api"
+import {ipcRendererFactory} from "test/__stubs__/ipcRenderer"
+import {jsonSerializer} from "test/__stubs__/serializers"
+import {newMnemonics} from "app/renderer/api/newMnemonics"
+import {routes} from "app/main/api"
+
+describe("NewMnemonics API", () => {
+  const mnemonics = {
+    mnemonics: "narrow flavor sense humble radar rail rail cactus radar broom oyster gym"
+  }
+  const messageHandler = jest.fn()
+  messageHandler.mockResolvedValue(mnemonics)
+  const options = {
+    ...api.defaultOptions,
+    timeout: 0,
+    idGen: () => "some generated id",
+    json: jsonSerializer,
+    ipc: ipcRendererFactory(),
+    messageHandler
+  }
+  const client = new api.Client(options)
+
+  it("should return valid mnemonics", async () => {
+    const response = await newMnemonics(client)
+    expect(response).toMatchObject(mnemonics)
+  })
+
+  it("should send a correct routed JSON-RPC request", async () => {
+    const expected = {
+      jsonrpc: "2.0",
+      id: "some generated id",
+      method: "newMnemonics",
+      params: []
+    }
+
+    await newMnemonics(client)
+
+    // Check that the request method is in the routes of the main process
+    expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)
+
+    // Check that the message handler function has been called correctly
+    expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
+  })
+
+})


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This pull request adds the functionality of creating new mnemonics in order to create new wallets.

The main process:
  - uses the crypto library to get new mnemonics
  - updates the application state with the unconsolidated wallet created from these new mnemonics
  - defines a handler to export this functionality to the renderer process through the IPC API

The renderer process:
  - defines a function that abstracts from the newMnemonics IPC API call and returns the generated mnemonics

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md