### PR TITLE
feat(store): expose ipcRenderer API client to Redux

### DIFF
--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -7,16 +7,23 @@ import { AppContainer } from "react-hot-loader"
 import Root from "./ui/containers/Root"
 import "./ui/app.global.scss"
 
-const client = new Client()
+const apiClient = new Client()
 
 new Promise(async () => {
   // Query and parse wallets from main process
-  const _wallets = await client.request("getWallets")
+  // TODO: replace these two lines with with `const wallets = await api.getWallets(apiClient)`
+  const _wallets = await apiClient.request("getWallets")
   const wallets = asRuntimeType(_wallets, Wallets, Contexts.IPC)
+
+  // This object holds resources that are shared among different parts of the app and unifies
+  // dependency injection.
+  const services = {
+    apiClient
+  }
 
   // Configure and initialize Redux store
   const { configureStore, history } = require("./store/configureStore")
-  const store = configureStore({ wallets })
+  const store = configureStore({ wallets }, services)
 
   // Root component rendering
   render(

--- a/app/renderer/services.ts
+++ b/app/renderer/services.ts
@@ -1,0 +1,5 @@
+import { Client } from "app/renderer/api"
+
+export type Services = {
+  apiClient: Client
+}

--- a/app/renderer/store/configureStore.development.ts
+++ b/app/renderer/store/configureStore.development.ts
@@ -22,7 +22,7 @@ const actionCreators = Object.assign({},
   { push }
 )
 
-const logger = (createLogger as any)({
+const logger = createLogger({
   level: "info",
   collapsed: true
 })

--- a/app/renderer/store/configureStore.production.ts
+++ b/app/renderer/store/configureStore.production.ts
@@ -1,9 +1,10 @@
-import { createStore, applyMiddleware, compose } from "redux"
-import thunk from "redux-thunk"
-import { createHashHistory } from "history"
-import { connectRouter, routerMiddleware } from "connected-react-router"
-import { createLogger } from "redux-logger"
 import rootReducer, { StoreState } from "app/renderer/reducers"
+import { Services } from "app/renderer/services"
+import createHashHistory from "history/createHashHistory"
+import { applyMiddleware, compose, createStore } from "redux"
+import { createLogger } from "redux-logger"
+import { connectRouter, routerMiddleware } from "connected-react-router"
+import thunk from "redux-thunk"
 
 const logger = (createLogger as any)({
   level: "info",
@@ -13,25 +14,25 @@ const logger = (createLogger as any)({
 const history = createHashHistory()
 const router = routerMiddleware(history)
 
-const middlewares: Array<any> = [thunk, router]
-if (process.env.NODE_ENV === "development") {
-  middlewares.push(logger)
-}
+/**
+ * This function is exposed to the renderer process' index in order to let it create the store with
+ * all the needed services or enhancers passed to it using dependency injection.
+ * @param initialState
+ * @param services
+ */
+function configureStore(initialState: StoreState, services: Services) {
 
-/* eslint-enable no-underscore-dangle */
-const enhancer = compose(
-  applyMiddleware.apply(undefined, middlewares)
-)
+  const middlewares = [thunk.withExtraArgument(services), router]
+  if (process.env.NODE_ENV === "development") {
+    middlewares.push(logger)
+  }
+
+  const enhancer = compose(applyMiddleware.apply(undefined, middlewares))
+
+  return createStore<StoreState>(connectRouter(history)(rootReducer), initialState, enhancer)
+}
 
 export = {
   history,
-  configureStore(initialState: StoreState) {
-    const store = createStore<StoreState>(
-      connectRouter(history)(rootReducer),
-      initialState,
-      enhancer
-    )
-
-    return store
-  }
+  configureStore
 }

--- a/app/renderer/store/configureStore.production.ts
+++ b/app/renderer/store/configureStore.production.ts
@@ -1,15 +1,9 @@
 import rootReducer, { StoreState } from "app/renderer/reducers"
 import { Services } from "app/renderer/services"
+import { connectRouter, routerMiddleware } from "connected-react-router"
 import createHashHistory from "history/createHashHistory"
 import { applyMiddleware, compose, createStore } from "redux"
-import { createLogger } from "redux-logger"
-import { connectRouter, routerMiddleware } from "connected-react-router"
 import thunk from "redux-thunk"
-
-const logger = (createLogger as any)({
-  level: "info",
-  collapsed: true
-})
 
 const history = createHashHistory()
 const router = routerMiddleware(history)
@@ -23,9 +17,6 @@ const router = routerMiddleware(history)
 function configureStore(initialState: StoreState, services: Services) {
 
   const middlewares = [thunk.withExtraArgument(services), router]
-  if (process.env.NODE_ENV === "development") {
-    middlewares.push(logger)
-  }
 
   const enhancer = compose(applyMiddleware.apply(undefined, middlewares))
 


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't actually perform all of these steps.**

# Why this change is necessary and useful

This leverages `redux-thunk` extensibility to inject a "services" object into action creator functions. This object only provides apiClient at the moment, but it can hold whatever other objects we may need to use in Redux action creators in the future.

More info about the solution can be found in #239.

fix #239

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
