### PR TITLE
refactor(ipc): refactor ipc params to be JsonSerializable, not array

### DIFF
--- a/app/common/ipc-protocol.ts
+++ b/app/common/ipc-protocol.ts
@@ -39,7 +39,7 @@ export const Id = t.union([t.string, t.number, t.nullType])
 export type Id = t.TypeOf<typeof Id>
 
 /** Params runtime type */
-export const Params = t.array(JsonRT)
+export const Params = JsonRT
 
 /** Params type */
 export type Params = t.TypeOf<typeof Params>

--- a/app/main/api/handlers/echo.ts
+++ b/app/main/api/handlers/echo.ts
@@ -3,7 +3,7 @@ import log from "app/common/logging"
 /**
  * Echo handler
  */
-async function echo(system: any, params: Array<any>) {
+async function echo(system: any, params: any) {
   log.debug(`I got: ${JSON.stringify(params)}`)
 
   return params

--- a/app/main/api/handlers/index.ts
+++ b/app/main/api/handlers/index.ts
@@ -8,4 +8,4 @@ export { default as error } from "./error"
 export { default as newMnemonics } from "./newMnemonics"
 
 export type Handler<T> =
-  (system: T, params: Array<JsonSerializable>) => Promise<JsonSerializable | void>
+  (system: T, params: JsonSerializable) => Promise<JsonSerializable | void>

--- a/app/main/api/handlers/nop.ts
+++ b/app/main/api/handlers/nop.ts
@@ -3,7 +3,7 @@ import log from "app/common/logging"
 /**
  * Void handler
  */
-async function nop(system: any, params: Array<any>) {
+async function nop(system: any, params: any) {
   log.info(`[NOP Handler] Ignoring message: ${params.join(", ")}`)
 }
 

--- a/app/main/api/index.ts
+++ b/app/main/api/index.ts
@@ -74,7 +74,7 @@ function genericListenerFactory(sendResponseMessage: ResponseFunction) {
             try {
               // Step 4/4: Invoke the method handler for `request.method` and try to invoke it
               // with `request.params`
-              const params = request.params || []
+              const params = request.params || null
               const result = await methodHandler(system, params)
               response = protocol.successResponse(
                 result === undefined ? null : result,

--- a/app/renderer/api/index.ts
+++ b/app/renderer/api/index.ts
@@ -6,7 +6,11 @@
 import log from "app/common/logging"
 import * as protocol from "app/common/ipc-protocol"
 import * as ipc from "app/renderer/ipc"
-import { jsonSerializer, JsonSerializer } from "app/common/serializers"
+import {
+  JsonSerializable,
+  jsonSerializer,
+  JsonSerializer
+} from "app/common/serializers"
 
 /**
  * Exports API renderer functions
@@ -83,8 +87,8 @@ export class Client implements ApiClient {
    * value in case of success, or a rejected Promise in case of any error in
    * preparing the payload of the request.
    */
-  public async notify(method: string, ...args: Array<any>): Promise<void> {
-    return this.send(method, args).then((result) => undefined)
+  public async notify(method: string, params: JsonSerializable = null): Promise<void> {
+    return this.send(method, params).then((result) => undefined)
   }
 
   /** Invokes `method` asynchronously in IPC Main process as a request.
@@ -93,15 +97,16 @@ export class Client implements ApiClient {
    * a response doesn't arrive in `ipc.timeout` milliseconds (by default) or if
    * any error ocurrs preparing the payload of the request.
    */
-  public async request(method: string, ...args: Array<any>): Promise<any> {
-    return this.send(method, args, this.options.idGen())
+  public async request(method: string, params: JsonSerializable = null): Promise<any> {
+    return this.send(method, params, this.options.idGen())
   }
 
   /** Helper method that contains the common logic for sending requests or notifications. */
-  private async send(method: string, args: Array<any>, id?: string | number): Promise<any> {
+  private async send(method: string, params: JsonSerializable, id?: string | number): Promise<any> {
     const { channel, timeout, ipc, json, messageHandler } = this.options
     const replyChannel = id ? protocol.replyChannel(id) : null
-    const request = id ? protocol.request(method, id, args) : protocol.notification(method, args)
+    const request = id ? protocol.request(method, id, params) :
+      protocol.notification(method, params)
 
     return new Promise((resolve, reject) => {
       if (replyChannel) {

--- a/test/app/common/ipc-protocol.fixtures.ts
+++ b/test/app/common/ipc-protocol.fixtures.ts
@@ -5,7 +5,9 @@ export const requests = {
     { jsonrpc: "2.0", id: null, method: "sum" },
     { jsonrpc: "2.0", id: "123", method: "sum" },
     { jsonrpc: "2.0", id: 123, method: "sum" },
-    { jsonrpc: "2.0", id: 123, method: "sum", params: [1, 2, 3] }
+    { jsonrpc: "2.0", id: 123, method: "sum", params: [1, 2, 3] },
+    { jsonrpc: "2.0", method: "sum", params: "1 2 3" },
+    { jsonrpc: "2.0", id: 123, method: "sum", params: { a: 1, b: 2, c: 3 } }
   ],
 
   invalid: [
@@ -13,11 +15,6 @@ export const requests = {
     { jsonrpc: "3.0", method: "sum" },
     { jsonrpc: "2.0", id: true, method: "sum" },
     { jsonrpc: "2.0", id: 123, method: 123 },
-    { jsonrpc: "2.0", method: "sum", params: "1 2 3" },
-    // This is a valid request in JSON-RPC, but since all requests are going to be behind a function
-    // signature wich is translated always into a list of parameters, we are forbidding this type
-    // of requests to make the implementation simpler
-    { jsonrpc: "2.0", id: 123, method: "sum", params: { a: 1, b: 2, c: 3 } }
   ]
 }
 

--- a/test/app/renderer/api.spec.ts
+++ b/test/app/renderer/api.spec.ts
@@ -73,7 +73,7 @@ describe("api", () => {
           method: "someMethod",
           params: [1, 2, 3]
         }
-        await client.request("someMethod", 1, 2, 3)
+        await client.request("someMethod", [1, 2, 3])
 
         expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
       })
@@ -145,7 +145,7 @@ describe("api", () => {
           ipc: ipcRendererFactory()
         })
         clientWithHandler.options.ipc.once("chan", messageHandler)
-        await clientWithHandler.notify("someMethod", 1, 2, 3)
+        await clientWithHandler.notify("someMethod", [1, 2, 3])
 
         expect(messageHandler).toBeCalledWith("event", expected)
       })

--- a/test/app/renderer/api/newMnemonics.spec.ts
+++ b/test/app/renderer/api/newMnemonics.spec.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:no-null-keyword */
+
 import {ipcRendererFactory} from "test/__stubs__/ipcRenderer"
 import {jsonSerializer} from "test/__stubs__/serializers"
 import * as api from "app/renderer/api"
@@ -29,7 +31,7 @@ describe("NewMnemonics API", () => {
       jsonrpc: "2.0",
       id: "some generated id",
       method: "newMnemonics",
-      params: []
+      params: null
     }
 
     // Call newMnemonics renderer function to trigger a JSON-RPC request and wait for the response


### PR DESCRIPTION
re #245

# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt-verify`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR refactors IPC params from Array<JsonSerializable> to JsonSerializable. This change is introduced mainly to avoid using io-ts/tuple to wrap every runtime type.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
