### PR TITLE
feat(ui&store): list wallets (soft login page) with actions/reducers logic

### DIFF
--- a/app/renderer/actions/actionNames.ts
+++ b/app/renderer/actions/actionNames.ts
@@ -1,0 +1,9 @@
+// Names of the action types for the wallet reducer
+export const SAVE_WALLET = "SAVE_WALLET"
+
+// Names of the action types for the forms reducer
+export const UPDATE_SOFT_LOGIN = "UPDATE_SOFT_LOGIN"
+
+// Names of the action types for the soft-login reducer under the forms reducer
+export const SET_FIELD = "SL_SET_FIELD"
+export const DELETE_FIELD = "SL_DELETE_FIELD"

--- a/app/renderer/actions/actionTypes.ts
+++ b/app/renderer/actions/actionTypes.ts
@@ -1,0 +1,13 @@
+import { SoftLoginForm } from "app/renderer/store"
+import { IActionWithPayload } from "app/renderer/actions/helpers"
+import { Wallet } from "app/common/runtimeTypes/storage/wallets"
+
+// Types for the actions that arrive at the soft login reducer
+export type SoftLoginKey = keyof SoftLoginForm
+export type SoftLoginAction = IActionWithPayload<Partial<SoftLoginForm> | SoftLoginKey>
+
+// Types for the actions that arrive at the forms reducer
+export type FormsAction = IActionWithPayload<SoftLoginAction>
+
+// Types for the actions that arrive at the wallet reducer
+export type SaveWalletAction = IActionWithPayload<Wallet>

--- a/app/renderer/actions/softLogin.ts
+++ b/app/renderer/actions/softLogin.ts
@@ -1,0 +1,58 @@
+import { actionCreator } from "./helpers"
+import * as Actions from "app/renderer/actions/actionNames"
+import * as api from "app/renderer/api"
+import { Wallet } from "app/common/runtimeTypes/storage/wallets"
+import { Services } from "app/renderer/services"
+import {
+  FormsAction,
+  SaveWalletAction,
+  SoftLoginAction,
+  SoftLoginKey
+} from "app/renderer/actions/actionTypes"
+import { SoftLoginForm } from "app/renderer/store"
+import { push } from "connected-react-router"
+
+// Action creators to set/delete fields in form
+export const setId = (id: string) => setField({ id })
+export const setPassword = (password: string) => setField({ password })
+export const setErrorMessage = (errorMessage: string) => setField({ errorMessage })
+export const setUnlockInProgress = (unlockInProgress: boolean) => setField({ unlockInProgress })
+export const deleteId = () => deleteField("id")
+export const deletePassword = () => deleteField("password")
+export const deleteUnlockInProgress = () => deleteField("unlockInProgress")
+
+// Internal action creators to set/delete a generic field in form
+const setField = (field: Partial<SoftLoginForm>): FormsAction => {
+  const softLoginAction = actionCreator<Partial<SoftLoginForm>>(Actions.SET_FIELD)(field)
+
+  return actionCreator<SoftLoginAction>(Actions.UPDATE_SOFT_LOGIN)(softLoginAction)
+}
+const deleteField = (key: SoftLoginKey): FormsAction => {
+  const softLoginAction = actionCreator<SoftLoginKey>(Actions.DELETE_FIELD)(key)
+
+  return actionCreator<SoftLoginAction>(Actions.UPDATE_SOFT_LOGIN)(softLoginAction)
+}
+
+// Action creator to unlock a wallet
+export const unlockWallet = (id: string, password: string) => {
+  return async (dispatch: any, getState: any, services: Services) => {
+    return new Promise((resolve, reject) => {
+      // Try to retrieve wallet from renderer API & dispatch wallet or error
+      api.getWallet(services.apiClient, id, password)
+        .then((wallet: Wallet) => {
+          dispatch(saveWallet(wallet))
+          dispatch(push("/"))
+          resolve()
+        })
+        .catch((err: Error) => {
+          dispatch(setErrorMessage(err.message))
+          reject()
+        })
+    })
+  }
+}
+
+// Internal action creator to save wallet
+const saveWallet = (wallet: Wallet): SaveWalletAction => {
+  return actionCreator<Wallet>(Actions.SAVE_WALLET)(wallet)
+}

--- a/app/renderer/api/getWallet.ts
+++ b/app/renderer/api/getWallet.ts
@@ -1,0 +1,15 @@
+import { Contexts, asRuntimeType } from "app/common/runtimeTypes"
+import { ApiClient } from "app/renderer/api"
+import { Wallet } from "app/common/runtimeTypes/storage/wallets"
+
+/**
+ * Function to request the unlock of a wallet through the API Client
+ * @param client
+ */
+export async function getWallet(client: ApiClient, id: string, password: string): Promise<Wallet> {
+  // Request the unlock of a wallet
+  const wallet = await client.request("getWallet", { id, password })
+
+  // Cast return value to runtime type
+  return asRuntimeType(wallet, Wallet, Contexts.IPC)
+}

--- a/app/renderer/api/getWallets.ts
+++ b/app/renderer/api/getWallets.ts
@@ -1,0 +1,15 @@
+import { Contexts, asRuntimeType } from "app/common/runtimeTypes"
+import { ApiClient } from "app/renderer/api"
+import { Wallets } from "app/common/runtimeTypes/storage/wallets"
+
+/**
+ * Function to request the unlock of a wallet through the API Client
+ * @param client
+ */
+export async function getWallets(client: ApiClient): Promise<Wallets> {
+  // Request all available wallets
+  const wallets = await client.request("getWallets")
+
+  // Cast return value to runtime type
+  return asRuntimeType(wallets, Wallets, Contexts.IPC)
+}

--- a/app/renderer/api/index.ts
+++ b/app/renderer/api/index.ts
@@ -16,6 +16,8 @@ import {
  * Exports API renderer functions
  */
 export { newMnemonics } from "./newMnemonics"
+export { getWallets } from "./getWallets"
+export { getWallet } from "./getWallet"
 
 /** Options type expected by `Client` */
 export type Options = {

--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -20,7 +20,7 @@ new Promise(async () => {
 
   // Configure and initialize Redux store
   const { configureStore, history } = require("./store/configureStore")
-  const store = configureStore({ wallets }, services)
+  const store = configureStore({ wallets, wallet: false, forms: { softLogin: {} } }, services)
 
   // Root component rendering
   render(

--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -1,19 +1,16 @@
-import { asRuntimeType, Contexts } from "app/common/runtimeTypes"
 import { Wallets } from "app/common/runtimeTypes/storage/wallets"
-import { Client } from "app/renderer/api"
+import * as api from "app/renderer/api"
 import * as React from "react"
 import { render } from "react-dom"
 import { AppContainer } from "react-hot-loader"
 import Root from "./ui/containers/Root"
 import "./ui/app.global.scss"
 
-const apiClient = new Client()
+const apiClient = new api.Client()
 
 new Promise(async () => {
   // Query and parse wallets from main process
-  // TODO: replace these two lines with with `const wallets = await api.getWallets(apiClient)`
-  const _wallets = await apiClient.request("getWallets")
-  const wallets = asRuntimeType(_wallets, Wallets, Contexts.IPC)
+  const wallets: Wallets = await api.getWallets(apiClient)
 
   // This object holds resources that are shared among different parts of the app and unifies
   // dependency injection.

--- a/app/renderer/reducers/forms.ts
+++ b/app/renderer/reducers/forms.ts
@@ -1,0 +1,47 @@
+import { AppForms, SoftLoginForm } from "app/renderer/store"
+import * as Actions from "app/renderer/actions/actionNames"
+import {
+  FormsAction,
+  SoftLoginAction,
+} from "app/renderer/actions/actionTypes"
+
+const defaultAppForms: AppForms = { softLogin: {} }
+
+export const formsReducer = (forms = defaultAppForms, action: FormsAction): AppForms => {
+  switch (action.type) {
+    case Actions.UPDATE_SOFT_LOGIN:
+      return { softLogin: softLoginReducer(forms.softLogin, action.payload) }
+    default:
+      return forms
+  }
+}
+
+const softLoginReducer = (softLogin: SoftLoginForm, action: SoftLoginAction): SoftLoginForm => {
+  switch (action.type) {
+    case Actions.SET_FIELD:
+      // Check if a partial of the soft login form was received
+      if (typeof action.payload === "object") {
+        return { ...softLogin, ...action.payload }
+      }
+      break
+    case Actions.DELETE_FIELD:
+      // Check if a key of the soft login form was received
+      if (typeof action.payload === "string") {
+        if (action.payload in softLogin) {
+          // Create a copy of current softLogin state
+          const newState = { ...softLogin }
+
+          // Remove the key from the copy of the state
+          delete newState[action.payload]
+
+          // Return the new state
+          return newState
+        }
+      }
+      break
+    default:
+      return softLogin
+  }
+
+  return softLogin
+}

--- a/app/renderer/reducers/index.ts
+++ b/app/renderer/reducers/index.ts
@@ -1,13 +1,14 @@
-import { walletsReducer, WalletsState } from "app/renderer/reducers/wallets"
 import { combineReducers, Reducer } from "redux"
+import { walletsReducer } from "app/renderer/reducers/wallets"
+import { walletReducer } from "app/renderer/reducers/wallet"
+import { formsReducer } from "app/renderer/reducers/forms"
+import { StoreState } from "app/renderer/store"
 
 // Combine all the relevant Redux reducers
 const rootReducer = combineReducers({
   wallets: walletsReducer,
+  wallet: walletReducer,
+  forms: formsReducer,
 }) as Reducer<StoreState>
-
-export interface StoreState {
-  wallets: WalletsState
-}
 
 export default rootReducer

--- a/app/renderer/reducers/wallet.ts
+++ b/app/renderer/reducers/wallet.ts
@@ -1,0 +1,15 @@
+import * as Actions from "app/renderer/actions/actionNames"
+import { WalletOption } from "app/renderer/store"
+import { SaveWalletAction } from "app/renderer/actions/actionTypes"
+
+const defaultWalletState: WalletOption = false
+
+export const walletReducer = (state: WalletOption = defaultWalletState,
+  action: SaveWalletAction): WalletOption => {
+  switch (action.type) {
+    case Actions.SAVE_WALLET:
+      return action.payload
+    default:
+      return state
+  }
+}

--- a/app/renderer/reducers/wallets.ts
+++ b/app/renderer/reducers/wallets.ts
@@ -1,10 +1,8 @@
 import { Wallets } from "app/common/runtimeTypes/storage/wallets"
 import { IAction } from "app/renderer/actions/helpers"
 
-export type WalletsState = Wallets
+const defaultWalletsState: Wallets = []
 
-const defaultWalletsState: WalletsState = []
-
-export const walletsReducer = (state = defaultWalletsState, action: IAction): WalletsState => {
+export const walletsReducer = (state = defaultWalletsState, action: IAction): Wallets => {
   return state
 }

--- a/app/renderer/routes.tsx
+++ b/app/renderer/routes.tsx
@@ -1,12 +1,15 @@
-import { StoreState } from "app/renderer/reducers"
 import { SignupPage } from "app/renderer/ui/pages/signup"
-import { GuardedRoute, ifWallets } from "app/renderer/utils/guardedRoute"
 import * as React from "react"
-import { Route, Switch } from "react-router"
+import { Route } from "react-router"
 import { Store } from "redux"
 
 import App from "./ui/containers/App"
 import { MainPage } from "./ui/pages/main"
+import { StoreState } from "./store"
+
+import { RedirectedRoute } from "app/renderer/utils/redirectedRoute"
+import { ifWallet, ifWallets } from "app/renderer/utils/guards"
+import SoftLoginPage from "app/renderer/ui/containers/SoftLoginPage"
 
 type RoutesProps = {
   store: Store<StoreState>
@@ -17,11 +20,22 @@ export default (props: RoutesProps) => {
 
   return (
     <App>
-      <Switch>
-        <GuardedRoute path="/" guard={ifWallets(store)} aCompo={MainPage} bCompo={SignupPage} />
-        <GuardedRoute path="/main" guard={ifWallets(store)} aCompo={MainPage} bCompo={SignupPage} />
-        <Route path="/wallets/new" component={SignupPage} />
-      </Switch>
+      <RedirectedRoute
+        path="/"
+        guard={ifWallet(store)}
+        aCompo={MainPage}
+        redirect="/login"
+      />
+      <RedirectedRoute
+        path="/login"
+        guard={ifWallets(store)}
+        aCompo={SoftLoginPage}
+        redirect="/wallets/new"
+      />
+      <Route
+        path="/wallets/new"
+        component={SignupPage}
+      />
     </App>
   )
 }

--- a/app/renderer/store/configureStore.development.ts
+++ b/app/renderer/store/configureStore.development.ts
@@ -4,7 +4,8 @@ import thunk from "redux-thunk"
 import { createHashHistory } from "history"
 import { connectRouter, push, routerMiddleware } from "connected-react-router"
 import { createLogger } from "redux-logger"
-import rootReducer, { StoreState } from "app/renderer/reducers"
+import rootReducer from "app/renderer/reducers"
+import { StoreState } from "./index"
 
 declare const window: Window & {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?(a: any): void
@@ -64,7 +65,7 @@ function configureStore(initialState: StoreState, services: Services) {
   if (module.hot) {
     module.hot.accept("app/renderer/reducers", () => {
       // eslint-disable-line global-require
-      store.replaceReducer(require("app/renderer/reducers"))
+      store.replaceReducer(require("app/renderer/reducers").default)
     })
   }
 

--- a/app/renderer/store/configureStore.production.ts
+++ b/app/renderer/store/configureStore.production.ts
@@ -1,9 +1,10 @@
-import rootReducer, { StoreState } from "app/renderer/reducers"
+import rootReducer from "app/renderer/reducers"
 import { Services } from "app/renderer/services"
 import { connectRouter, routerMiddleware } from "connected-react-router"
 import createHashHistory from "history/createHashHistory"
 import { applyMiddleware, compose, createStore } from "redux"
 import thunk from "redux-thunk"
+import { StoreState } from "./index"
 
 const history = createHashHistory()
 const router = routerMiddleware(history)

--- a/app/renderer/store/index.ts
+++ b/app/renderer/store/index.ts
@@ -1,0 +1,24 @@
+import { Wallets, Wallet } from "app/common/runtimeTypes/storage/wallets"
+
+// Optional state for the wallet
+export type WalletOption = Wallet | false
+
+// State for the soft login page
+export interface SoftLoginForm {
+  id?: string
+  password?: string
+  unlockInProgress?: boolean
+  errorMessage?: string
+}
+
+// State for the forms in all the pages
+export interface AppForms {
+  softLogin: SoftLoginForm
+}
+
+// Main store state
+export interface StoreState {
+  wallets: Wallets
+  wallet: WalletOption
+  forms: AppForms
+}

--- a/app/renderer/ui/components/card/default/index.tsx
+++ b/app/renderer/ui/components/card/default/index.tsx
@@ -6,7 +6,7 @@ const styles = require("./style.scss")
 
 export interface Iprops {
   className?: string
-  title: string
+  title?: string
   style?: React.CSSProperties
 }
 

--- a/app/renderer/ui/components/card/navigation/index.tsx
+++ b/app/renderer/ui/components/card/navigation/index.tsx
@@ -10,7 +10,9 @@ export interface Iprops {
   className?: string
   nextStep?: any
   previousStep?: any
-  title: string
+  title?: string
+  backText?: string
+  nextText?: string
 }
 
 /**
@@ -32,8 +34,14 @@ export default class Cardnavigation extends React.Component<Iprops> {
             {this.props.children}
           </div>
           <div className={styles.navigation}>
-            <ButtonNavigation text="Back" onClick={this.props.previousStep} />
-            <ButtonNavigation text="Next" onClick={this.props.nextStep} />
+            <ButtonNavigation
+              text={this.props.backText ? this.props.backText : "Back"}
+              onClick={this.props.previousStep}
+            />
+            <ButtonNavigation
+              text={this.props.nextText ? this.props.nextText : "Next"}
+              onClick={this.props.nextStep}
+            />
           </div>
         </Card>
       </div>

--- a/app/renderer/ui/components/input/default/index.tsx
+++ b/app/renderer/ui/components/input/default/index.tsx
@@ -4,21 +4,29 @@ import { Input } from "antd"
 
 export interface Iprops {
   className?: string
+  type?: string
+  onChange?: any
+  onBlur?: any
 }
 
 /**
  * Default input UI component
  *
  * @export
- * @class InputuDefault
+ * @class InputDefault
  * @extends {React.Component<Iprops>}
  */
 
-export default class InputuDefault extends React.Component<Iprops> {
+export default class InputDefault extends React.Component<Iprops> {
   // tslint:disable-next-line: completed-docs
   public render() {
     return (
-      <Input className={this.props.className} />
+      <Input
+        className={this.props.className}
+        type={this.props.type}
+        onChange={this.props.onChange}
+        onBlur={this.props.onBlur}
+      />
     )
   }
 }

--- a/app/renderer/ui/containers/SoftLoginPage.tsx
+++ b/app/renderer/ui/containers/SoftLoginPage.tsx
@@ -1,0 +1,34 @@
+import { Wallets } from "app/common/runtimeTypes/storage/wallets"
+import { SoftLoginForm, StoreState } from "app/renderer/store"
+import { bindActionCreators, Dispatch } from "redux"
+import { IAction } from "app/renderer/actions/helpers"
+import * as actionCreators from "app/renderer/actions/softLogin"
+import { connect } from "react-redux"
+import { SoftLogin } from "app/renderer/ui/pages/softLogin"
+
+export interface StateProps {
+  wallets: Wallets,
+  loginForm: SoftLoginForm
+}
+
+export interface DispatchProps {
+  actions: any
+}
+
+const mapStateToProps = (state: StoreState): StateProps => {
+  return ({
+    wallets: state.wallets,
+    loginForm: state.forms.softLogin
+  })
+}
+
+const mapDispatchToProps = (dispatch: Dispatch<IAction>): DispatchProps => {
+  return {
+    actions: bindActionCreators(actionCreators, dispatch)
+  }
+}
+
+export default connect<StateProps, DispatchProps, {}, StoreState>(
+  mapStateToProps,
+  mapDispatchToProps
+)(SoftLogin)

--- a/app/renderer/ui/pages/main/sections/wallet/tabs/transactions/index.tsx
+++ b/app/renderer/ui/pages/main/sections/wallet/tabs/transactions/index.tsx
@@ -61,7 +61,7 @@ class Transactions extends TabComponent<any> {
             actions={confirmedOptions}
             className={styles["vesting-graph"]}
           >
-            <p>Comming soon... D3 GRAPH</p>
+            <p>Coming soon... D3 GRAPH</p>
           </Wrapper>
         </div>
       </>

--- a/app/renderer/ui/pages/signup/index.tsx
+++ b/app/renderer/ui/pages/signup/index.tsx
@@ -11,7 +11,7 @@ import Welcome from "./steps/welcome/index"
 const styles = require("./style.scss")
 
 /**
- * SingupPage component
+ * SignupPage component
  *
  * @export
  * @class Signup

--- a/app/renderer/ui/pages/signup/steps/adressesGeneration/index.tsx
+++ b/app/renderer/ui/pages/signup/steps/adressesGeneration/index.tsx
@@ -22,7 +22,7 @@ export default class AddressGeneration extends React.Component<Iprops> {
   public render() {
     return (
       <CardDefault className={this.props.className} title="Address generation">
-        <p className={styles.subtitle}>Sheika is now generating your addresses</p>
+        <p className={styles.subtitle}>Sheikah is now generating your addresses</p>
         <p className={styles.text}>This will take a few seconds</p>
       </CardDefault>
     )

--- a/app/renderer/ui/pages/signup/steps/walletSeedBackup/index.tsx
+++ b/app/renderer/ui/pages/signup/steps/walletSeedBackup/index.tsx
@@ -36,7 +36,7 @@ export default class WalletSeedBackup extends React.Component<Iprops> {
             <p>invite cover trim climb actress carbon only laptop loyal feel edit away</p>
           </div>
           <p>Please save this 12 words on paper (order is important). This seed will allow you to
-            recover your wallet in cse of computer failure.</p>
+            recover your wallet in case of computer failure.</p>
         </CardNavigation>
         <Alert className={styles["alert-grid"]}>
           <div className={styles.alert}>

--- a/app/renderer/ui/pages/signup/steps/walletSeedConfirmation/index.tsx
+++ b/app/renderer/ui/pages/signup/steps/walletSeedConfirmation/index.tsx
@@ -39,8 +39,8 @@ export default class WalletSeedConfirmation extends React.Component<Iprops> {
         <Alert className={styles["alert-grid"]}>
           <div className={styles.alert}>
             <p>Your seed is important!</p>
-            <p>If you loose your seed, your coins will be permanently lost.</p>
-            <p>To confirm that you have properly saved your seed, please retyped it here.</p>
+            <p>If you lose your seed, your coins will be permanently lost.</p>
+            <p>To confirm that you have properly saved your seed, please retype it here.</p>
           </div>
         </Alert>
       </>

--- a/app/renderer/ui/pages/signup/steps/welcome/index.tsx
+++ b/app/renderer/ui/pages/signup/steps/welcome/index.tsx
@@ -27,7 +27,7 @@ export default class Welcome extends React.Component<Iprops> {
     return (
       <CardDefault className={classNameCard} title="Hey, listen!">
         <p className={styles.subtitle}>
-          This assitant wil guide you through the process of creating your own Witnet wallet.
+          This assistant wil guide you through the process of creating your own Witnet wallet.
         </p>
         <p className={styles.text}>
           A wallet is an app that keeps your credentials safe and lets you interface with the

--- a/app/renderer/ui/pages/softLogin/index.tsx
+++ b/app/renderer/ui/pages/softLogin/index.tsx
@@ -22,23 +22,19 @@ enum Step {
  */
 export class SoftLogin extends React.Component<StateProps & DispatchProps> {
   /**
-   * Method to get current step from state
-   * @returns {any}
+   * Method to deduce step from state
    */
-  private getStepFromState = (): Step => {
-    // Check if unlock is in progress
-    if (("unlockInProgress" in this.props.loginForm) && (this.props.loginForm.unlockInProgress)) {
-      return Step.walletUnlockInProgress
-    }
-
-    // Check if there is no password
-    if ("id" in this.props.loginForm) {
-      return Step.walletPasswordRequest
-    }
-
-    // Default case
-    return Step.walletSelection
-  }
+  private guessStepFromState = (): Step =>
+    // If unlock is in progress
+    this.props.loginForm.unlockInProgress ?
+      // Show walletUnlockInProgress
+      Step.walletUnlockInProgress :
+      // Else if there's a selected wallet ID
+      this.props.loginForm.id ?
+        // Show walletPasswordRequest
+        Step.walletPasswordRequest :
+        // Else show walletSelection
+        Step.walletSelection
 
   /**
    * Method to go to request password step
@@ -86,7 +82,7 @@ export class SoftLogin extends React.Component<StateProps & DispatchProps> {
   public showStep() {
 
     // Get current state (from the information in the store)
-    const step = this.getStepFromState()
+    const step = this.guessStepFromState()
 
     switch (step) {
       case Step.walletSelection:

--- a/app/renderer/ui/pages/softLogin/index.tsx
+++ b/app/renderer/ui/pages/softLogin/index.tsx
@@ -1,0 +1,140 @@
+import * as React from "react"
+import WalletSelection from "./steps/walletSelection"
+import WalletPasswordRequest from "./steps/walletPasswordRequest"
+import WalletUnlockInProgress from "./steps/walletUnlockInProgress"
+import { DispatchProps, StateProps } from "app/renderer/ui/containers/SoftLoginPage"
+
+const styles = require("./style.scss")
+
+// Steps in the soft login page
+enum Step {
+  walletSelection,
+  walletPasswordRequest,
+  walletUnlockInProgress,
+}
+
+/**
+ * SoftLoginPage component
+ *
+ * @export
+ * @class SoftLoginPage
+ * @extends {React.Component}
+ */
+export class SoftLogin extends React.Component<StateProps & DispatchProps> {
+  /**
+   * Method to get current step from state
+   * @returns {any}
+   */
+  private getStepFromState = (): Step => {
+    // Check if unlock is in progress
+    if (("unlockInProgress" in this.props.loginForm) && (this.props.loginForm.unlockInProgress)) {
+      return Step.walletUnlockInProgress
+    }
+
+    // Check if there is no password
+    if ("id" in this.props.loginForm) {
+      return Step.walletPasswordRequest
+    }
+
+    // Default case
+    return Step.walletSelection
+  }
+
+  /**
+   * Method to go to request password step
+   * @param {string} id
+   */
+  private requestPassword = (id: string) => {
+    // Set id in the state
+    this.props.actions.setId(id)
+  }
+
+  /**
+   * Method to go to wallet selection step
+   */
+  private selectWallet = () => {
+    // Delete id, password and unlock in progress from the state
+    this.props.actions.deleteId()
+    this.props.actions.deletePassword()
+    this.props.actions.deleteUnlockInProgress()
+  }
+
+  /**
+   * Method to go to unlock wallet step
+   * @param {string} password
+   */
+  private unlockWallet = (password: string) => {
+    // Set password in the state
+    this.props.actions.setPassword(password)
+
+    // Set unlock progress in the state
+    this.props.actions.setUnlockInProgress(true)
+
+    // Try to unlock wallet
+    this.props.actions.unlockWallet(this.props.loginForm.id,
+      this.props.loginForm.password)
+      .then(this.selectWallet)
+      .catch(this.selectWallet)
+  }
+
+  /**
+   * Method that show soft login step according to state derived from store
+   *
+   * @returns Step component
+   * @memberof Signup
+   */
+  public showStep() {
+
+    // Get current state (from the information in the store)
+    const step = this.getStepFromState()
+
+    switch (step) {
+      case Step.walletSelection:
+        return (
+          <WalletSelection
+            className={styles.centered}
+            wallets={this.props.wallets}
+            nextStep={this.requestPassword}
+          />)
+      case Step.walletPasswordRequest:
+        return (
+          <WalletPasswordRequest
+            className={styles.centered}
+            prevStep={this.selectWallet}
+            nextStep={this.unlockWallet}
+          />)
+      case Step.walletUnlockInProgress:
+        return (
+          <WalletUnlockInProgress
+            className={styles.centered}
+          />)
+      default:
+        return (
+          <WalletSelection
+            className={styles.centered}
+            wallets={this.props.wallets}
+            nextStep={this.requestPassword}
+          />
+        )
+    }
+  }
+
+  /** render */
+  // tslint:disable-next-line:prefer-function-over-method completed-docs
+  public render() {
+    return (
+      <div className={styles.layout}>
+        <div className={styles.centered}>
+          <div className={styles.sidebar}>
+            <p className={styles.titleText}>Welcome back</p>
+            <div className={styles.settings}>
+              <i className={`fa fa-cog ${styles.icon}`} />
+              <span className={styles.label}>App Settings</span>
+            </div>
+          </div>
+          {this.showStep()}
+        </div>
+      </div>
+    )
+  }
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletPasswordRequest/index.tsx
+++ b/app/renderer/ui/pages/softLogin/steps/walletPasswordRequest/index.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+
+import { CardNavigation } from "app/renderer/ui/components/card"
+import InputDefault from "app/renderer/ui/components/input/default"
+
+const styles = require("./style.scss")
+
+export interface Iprops {
+  className?: any
+  prevStep: () => void
+  nextStep: (password: string) => void
+}
+
+/**
+ * Step walled password request UI component
+ *
+ * @export
+ * @class WalletPasswordRequest
+ * @extends {React.Component<Iprops>}
+ */
+export default class WalletPasswordRequest extends React.Component<Iprops> {
+  /**
+   * Local state to hold password
+   * @type {{password: string}}
+   */
+  public state = {
+    password: ""
+  }
+
+  /**
+   * Method to store password in the local state
+   * @param {React.FormEvent} event
+   */
+  private handlePassword = (event: React.FormEvent) => {
+    this.setState({ password: (event.target as any).value })
+  }
+
+  /**
+   * Method to move to the next step
+   */
+  private nextStep = () => { this.props.nextStep(this.state.password) }
+
+  /**
+   * Method to move to previous step
+   */
+  private prevStep = () => { this.props.prevStep() }
+
+  /** render */
+  // tslint:disable-next-line:prefer-function-over-method
+  public render() {
+    return (
+      <>
+        <CardNavigation
+          className={styles.step}
+          previousStep={this.prevStep}
+          nextStep={this.nextStep}
+          backText="Cancel"
+          nextText="Unlock"
+        >
+          <p>Please type here the password to unlock your wallet:</p>
+          <InputDefault
+            type="password"
+            onBlur={this.handlePassword}
+          />
+        </CardNavigation>
+      </>
+    )
+  }
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletPasswordRequest/style.scss
+++ b/app/renderer/ui/pages/softLogin/steps/walletPasswordRequest/style.scss
@@ -1,0 +1,8 @@
+:local {
+  @import "app/renderer/ui/colors";
+
+  .step {
+    background: $grey-1;
+    grid-column: 2;
+  }
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletSelection/index.tsx
+++ b/app/renderer/ui/pages/softLogin/steps/walletSelection/index.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+
+import { ButtonOption } from "app/renderer/ui/components/button"
+import { CardDefault } from "app/renderer/ui/components/card"
+import { Wallets } from "app/common/runtimeTypes/storage/wallets"
+
+const styles = require("./style.scss")
+
+export interface Iprops {
+  className?: any
+  wallets: Wallets
+  nextStep: (id: string) => void
+}
+
+/**
+ * Step welcome UI component
+ *
+ * @export
+ * @class Welcome
+ * @extends {React.Component<Iprops>}
+ */
+
+export default class WalletSelection extends React.Component<Iprops> {
+  /** render */
+  // tslint:disable-next-line:prefer-function-over-method
+  public render() {
+    return (
+      <CardDefault className={styles.step}>
+        <p className={styles.text}>
+          Select which wallet you want to unlock:
+        </p>
+        <div className={styles.links}>
+          {linksRender(this.props)}
+        </div>
+        <ButtonOption
+          className={styles.link}
+          secondaryText=">"
+          onClick={this.props.nextStep}
+        >
+          Create, import or recover a wallet
+        </ButtonOption>
+      </CardDefault>
+    )
+  }
+}
+
+// Function that calls next step function inside props
+const nextStep = (props: Iprops, id: string) => () => { props.nextStep(id) }
+
+// Function to render links to wallets
+const linksRender = (props: Iprops) => {
+  return props.wallets.map((wallet) => {
+    return (
+      <ButtonOption
+        key={wallet.id}
+        className={`${styles.link} ${styles.highlighted}`}
+        secondaryText=">"
+        onClick={nextStep(props, wallet.id)}
+      >
+        {wallet.caption}
+      </ButtonOption>)
+  })
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletSelection/style.scss
+++ b/app/renderer/ui/pages/softLogin/steps/walletSelection/style.scss
@@ -1,0 +1,52 @@
+:local {
+  @import "app/renderer/ui/colors";
+
+  .step {
+    background: $grey-1;
+    grid-column: 2;
+  }
+
+  .text {
+    color: $grey-9;
+    margin-bottom: 20px;
+  }
+
+  .links {
+    height: 265px;
+    overflow: auto;
+    padding-right: 10px;
+  }
+
+  /* width */
+  ::-webkit-scrollbar {
+    width: 10px;
+  }
+
+  /* Track */
+  ::-webkit-scrollbar-track {
+    background: #f1f1f1;
+    margin-bottom: 5px;
+    margin-top: 5px;
+  }
+
+  /* Handle */
+  ::-webkit-scrollbar-thumb {
+    background: #888;
+  }
+
+  /* Handle on hover */
+  ::-webkit-scrollbar-thumb:hover {
+    background: #555;
+  }
+
+  .link {
+    height: 60px;
+    margin-bottom: 5px;
+    margin-top: 5px;
+  }
+
+  .highlighted {
+    border-color: $blue-6;
+    color: $blue-6;
+  }
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletUnlockInProgress/index.tsx
+++ b/app/renderer/ui/pages/softLogin/steps/walletUnlockInProgress/index.tsx
@@ -1,0 +1,33 @@
+import * as React from "react"
+
+import CardDefault from "app/renderer/ui/components/card/default"
+
+const styles = require("./style.scss")
+
+export interface Iprops {
+  className?: any
+}
+
+/**
+ * Step walled password request UI component
+ *
+ * @export
+ * @class WalletPasswordRequest
+ * @extends {React.Component<Iprops>}
+ */
+
+export default class WalletUnlockInProgress extends React.Component<Iprops> {
+  /** render */
+  // tslint:disable-next-line:prefer-function-over-method
+  public render() {
+    /** render */
+    // tslint:disable-next-line:prefer-function-over-method
+    return (
+      <CardDefault className={styles.step}>
+        <p className={styles.subtitle}>Sheikah is trying to unlock your
+          wallet</p>
+        <p className={styles.text}>This will take a few seconds</p>
+      </CardDefault>
+    )
+  }
+}

--- a/app/renderer/ui/pages/softLogin/steps/walletUnlockInProgress/style.scss
+++ b/app/renderer/ui/pages/softLogin/steps/walletUnlockInProgress/style.scss
@@ -1,0 +1,19 @@
+:local {
+  @import "app/renderer/ui/colors";
+
+  .step {
+    background: $grey-1;
+    grid-column: 2;
+  }
+
+  .subtitle {
+    color: $blue-6;
+    font-size: 18px;
+    text-align: center;
+  }
+
+  .text {
+    color: $grey-8;
+    text-align: center;
+  }
+}

--- a/app/renderer/ui/pages/softLogin/style.scss
+++ b/app/renderer/ui/pages/softLogin/style.scss
@@ -1,0 +1,54 @@
+:local {
+  @import "app/renderer/ui/colors";
+
+  .layout {
+    background: $grey-6;
+    display: grid;
+    grid-template-columns: 1fr 700px 1fr;
+    grid-template-rows: 1fr 1fr 1fr;
+    height: 100vh;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  .centered {
+    display: grid;
+    grid-column: 2;
+    grid-row: 2;
+    grid-template-columns: 30% 1fr;
+    height: 500px;
+  }
+
+  .sidebar {
+    background: linear-gradient(to right, $purple-6, $blue-6);
+    border: 1px solid #e8e8e8;
+    box-shadow: 0 0 5px 0 #f5f5f5;
+    display: flex;
+    flex-direction: column;
+    grid-column: 1;
+    justify-content: space-between;
+  }
+
+  .titleText {
+    color: $grey-1;
+    font-size: 22px;
+    margin: 20px;
+  }
+
+  .settings {
+    display: flex;
+    font-size: 14px;
+    padding: 20px;
+
+    .icon {
+      align-self: center;
+      color: $grey-1;
+      display: flex;
+      margin-right: 10px;
+    }
+
+    .label {
+      color: $grey-1;
+    }
+  }
+}

--- a/app/renderer/utils/guardedRoute.tsx
+++ b/app/renderer/utils/guardedRoute.tsx
@@ -1,7 +1,5 @@
-import { StoreState } from "app/renderer/reducers"
 import * as React from "react"
 import { Route } from "react-router"
-import { Store } from "redux"
 
 /**
  * A guarded route renders component A or B depending on the result of executing a guard function
@@ -21,23 +19,5 @@ export class GuardedRoute extends React.Component<any> {
     }
 
     return <Route {...props} render={renderer} />
-  }
-
-}
-
-/**
- * All route guards must abide by this type.
- */
-type RouteGuard = (store: Store<StoreState>) => (props: any) => Boolean
-
-/**
- * This guard checks if there are wallets in the store.
- * @param store
- */
-export const ifWallets: RouteGuard = (store) => {
-  const state = store.getState()
-
-  return (props: any) => {
-    return state.wallets.length > 0
   }
 }

--- a/app/renderer/utils/guards.ts
+++ b/app/renderer/utils/guards.ts
@@ -1,0 +1,31 @@
+import { Store } from "redux"
+import { StoreState } from "app/renderer/store"
+
+/**
+ * All route guards must abide by this type.
+ */
+type RouteGuard = (store: Store<StoreState>) => (props: any) => boolean
+
+/**
+ * This guard checks if there are wallets in the store.
+ * @param store
+ */
+export const ifWallets: RouteGuard = (store) => {
+  const state = store.getState()
+
+  return (props: any) => {
+    return state.wallets.length > 0
+  }
+}
+
+/**
+ * This guard checks if there is a wallet in the store.
+ * @param store
+ */
+export const ifWallet: RouteGuard = (store) => {
+  const state = store.getState()
+
+  return (props: any) => {
+    return (state.wallet !== false)
+  }
+}

--- a/app/renderer/utils/redirectedRoute.tsx
+++ b/app/renderer/utils/redirectedRoute.tsx
@@ -1,0 +1,23 @@
+import * as React from "react"
+import { Redirect, Route } from "react-router"
+
+/**
+ * A guarded route renders component A or B depending on the result of executing a guard function
+ * with the arguments passed to the route.
+ */
+export class RedirectedRoute extends React.Component<any> {
+
+  /**
+   * Guarded route render function.
+   */
+  public render() {
+    const { aCompo: A, redirect: location, guard, ...props } = this.props
+
+    const renderer = (props: any) => {
+      return guard(props) ? <A {...props} /> : location ? <Redirect to={{ pathname: location }} /> :
+        <div>The guard of a guarded route failed without a redirect</div>
+    }
+
+    return <Route {...props} render={renderer} />
+  }
+}

--- a/test/app/renderer/api/getWallet.spec.ts
+++ b/test/app/renderer/api/getWallet.spec.ts
@@ -1,0 +1,59 @@
+import { ipcRendererFactory } from "test/__stubs__/ipcRenderer"
+import { jsonSerializer } from "test/__stubs__/serializers"
+import * as api from "app/renderer/api"
+//import { routes } from "app/main/api"
+import { Wallet } from "app/common/runtimeTypes/storage/wallets"
+
+describe("GetWallet API", () => {
+  const getWalletParams = {
+    id: "1",
+    password: "test-pwd"
+  }
+
+  const wallet: Wallet = {
+    id: "test",
+    caption: "test wallet",
+    seed: { kind: "Wip3", mnemonics: { mnemonics: "" }, xprv: "", xpub: "" },
+    epochs: { last: 0 },
+    purpose: 0x80000003,
+    accounts: []
+  }
+
+  const messageHandler = jest.fn()
+  messageHandler.mockResolvedValue(wallet)
+  const options = {
+    ...api.defaultOptions,
+    timeout: 0,
+    idGen: () => "some generated id",
+    json: jsonSerializer,
+    ipc: ipcRendererFactory(),
+    messageHandler
+  }
+  const client = new api.Client(options)
+
+  it("should return a valid wallet", async () => {
+    const response = await api.getWallet(client, getWalletParams.id, getWalletParams.password)
+    expect(response).toMatchObject(wallet)
+  })
+
+  it("should send a routable JSON-RPC request", async () => {
+    const expected = {
+      jsonrpc: "2.0",
+      id: "some generated id",
+      method: "getWallet",
+      params: getWalletParams
+    }
+
+    // Call getWallet renderer function to trigger a JSON-RPC request and
+    // wait for the response
+    await api.getWallet(client, getWalletParams.id, getWalletParams.password)
+
+    // Check that the requested method is in the routes of the main process
+    // TODO: uncomment when handler is implemented in main
+    //expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)
+
+    // Check that the message handler function has been called correctly
+    expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
+  })
+
+})

--- a/test/app/renderer/api/getWallets.spec.ts
+++ b/test/app/renderer/api/getWallets.spec.ts
@@ -1,0 +1,49 @@
+/* tslint:disable:no-null-keyword */
+
+import { ipcRendererFactory } from "test/__stubs__/ipcRenderer"
+import { jsonSerializer } from "test/__stubs__/serializers"
+import * as api from "app/renderer/api"
+import { routes } from "app/main/api"
+
+describe("GetWallets API", () => {
+  const wallets = [
+    { id: "1", caption: "My hot wallet" },
+    { id: "2", caption: "My TREZOR cold wallet" }
+  ]
+  const messageHandler = jest.fn()
+  messageHandler.mockResolvedValue(wallets)
+  const options = {
+    ...api.defaultOptions,
+    timeout: 0,
+    idGen: () => "some generated id",
+    json: jsonSerializer,
+    ipc: ipcRendererFactory(),
+    messageHandler
+  }
+  const client = new api.Client(options)
+
+  it("should return valid wallets", async () => {
+    const response = await api.getWallets(client)
+    expect(response).toMatchObject(wallets)
+  })
+
+  it("should send a routable JSON-RPC request", async () => {
+    const expected = {
+      jsonrpc: "2.0",
+      id: "some generated id",
+      method: "getWallets",
+      params: null
+    }
+
+    // Call getWallets renderer function to trigger a JSON-RPC request and
+    // wait for the response
+    await api.getWallets(client)
+
+    // Check that the requested method is in the routes of the main process
+    expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)
+
+    // Check that the message handler function has been called correctly
+    expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
+  })
+
+})

--- a/test/app/renderer/reducers/wallet.fixtures.ts
+++ b/test/app/renderer/reducers/wallet.fixtures.ts
@@ -1,0 +1,38 @@
+import { SaveWalletAction } from "app/renderer/actions/actionTypes"
+import { Wallet } from "app/common/runtimeTypes/storage/wallets"
+import { WalletOption } from "app/renderer/store"
+
+// Empty state
+export const emptyState: WalletOption = false
+
+// Non empty state
+export const nonEmptyState: WalletOption = {
+  id: "initial wallet",
+  caption: "initial wallet",
+  seed: { kind: "Wip3", mnemonics: { mnemonics: "" }, xprv: "", xpub: "" },
+  epochs: { last: 0 },
+  purpose: 0x80000003,
+  accounts: []
+}
+
+// Create dummy wallet
+export const newWallet: Wallet = {
+  id: "test wallet",
+  caption: "test wallet",
+  seed: { kind: "Wip3", mnemonics: { mnemonics: "" }, xprv: "", xpub: "" },
+  epochs: { last: 1 },
+  purpose: 0x80000003,
+  accounts: []
+}
+
+// Valid action to save a new wallet
+export const validSaveWalletAction: SaveWalletAction = {
+  type: "SAVE_WALLET",
+  payload: newWallet
+}
+
+// Invalid action to save a new wallet
+export const invalidSaveWalletAction: SaveWalletAction = {
+  type: "UNKNOWN_ACTION",
+  payload: newWallet
+}

--- a/test/app/renderer/reducers/wallet.spec.ts
+++ b/test/app/renderer/reducers/wallet.spec.ts
@@ -1,0 +1,28 @@
+import { walletReducer } from "app/renderer/reducers/wallet"
+import {
+  emptyState, validSaveWalletAction,
+  newWallet, nonEmptyState,
+  invalidSaveWalletAction
+} from "./wallet.fixtures"
+
+describe("Wallet renderer", () => {
+  it("should update empty state with valid action", async () => {
+    const newState = walletReducer(emptyState, validSaveWalletAction)
+    expect(newState).toMatchObject(newWallet)
+  })
+
+  it("should not update empty state with invalid action", async () => {
+    const newState = walletReducer(emptyState, invalidSaveWalletAction)
+    expect(newState).toBe(false)
+  })
+
+  it("should update non empty state with valid action", async () => {
+    const newState = walletReducer(nonEmptyState, validSaveWalletAction)
+    expect(newState).toMatchObject(newWallet)
+  })
+
+  it("should not update non empty state with invalid action", async () => {
+    const newState = walletReducer(nonEmptyState, invalidSaveWalletAction)
+    expect(newState).toMatchObject(nonEmptyState)
+  })
+})


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Basic implementation of the list wallets page (named soft login in the code). It consists of three steps ('Wallet selection', 'Request password for selected wallet' and 'Trying to unlock selected wallet').

Soft login state is in redux store and the transitions and between the steps and their rendering are ruled out by the such state.

Action creators and renderers that are triggered by the soft login page have been created. Actions are dispatched consequently when a user acts on the page.

Tests are left out of the PR for the time being to parallelize the implementation of the tests and the review of this PR.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
