### PR TITLE
refactor: newMnemonics handler

### DIFF
--- a/app/common/runtimeTypes/index.ts
+++ b/app/common/runtimeTypes/index.ts
@@ -1,5 +1,4 @@
 import { InvalidParamsError } from "app/common/ipc-protocol"
-import { JsonSerializable } from "app/common/serializers"
 import * as t from "io-ts"
 
 export const enum Contexts {
@@ -13,7 +12,8 @@ export const enum Contexts {
  * @param runtimeType
  * @param context
  */
-export function asRuntimeType<T>(input: t.mixed, runtimeType: t.Type<T>, context?: Contexts): T {
+export function asRuntimeType<T, U>
+  (input: t.mixed, runtimeType: t.Type<T, U>, context?: Contexts): T {
   return runtimeType.decode(input).getOrElseL(() => {
     const ctx = context ? ` from ${context}` : ""
     const errorMessage = `Got a non-compliant ${runtimeType.name}${ctx}: ${JSON.stringify(input)}`
@@ -26,8 +26,7 @@ export function asRuntimeType<T>(input: t.mixed, runtimeType: t.Type<T>, context
  * @param input
  * @param runtimeType
  */
-export function asObject<T extends JsonSerializable>
-  (input: T, runtimeType: t.Type<T>): JsonSerializable {
+export function asObject<T, U>(input: T, runtimeType: t.Type<T, U>): U {
   return runtimeType.encode(input)
 }
 

--- a/app/common/runtimeTypes/ipc/wallets.ts
+++ b/app/common/runtimeTypes/ipc/wallets.ts
@@ -13,42 +13,31 @@ export const ValidateMnemonicsParams = t.type({
 })
 export type ValidateMnemonicsParams = t.TypeOf<typeof ValidateMnemonicsParams>
 
-export namespace ValidateMnemonicsResponses {
-  // Success case
-  export const Id = t.type({
-    tag: t.literal("id"),
-    id: t.string
-  })
-  export type Id = t.TypeOf<typeof Id>
+const ValidateMnemonicsSuccess = t.type({
+  kind: t.literal("SUCCESS"),
+  id: t.string
+})
 
-  /** Factory function for `Id` response */
-  export function id(id: string): Id {
-    return { tag: "id", id }
-  }
-
-  // Error due to invalid mnemonic
-  export const Invalid = t.type({ tag: t.literal("invalid") })
-  export type Invalid = t.TypeOf<typeof Invalid>
-
-  /** Factory function for `Invalid` response */
-  export function invalid(): Invalid {
-    return { tag: "invalid" }
-  }
-
-  // Error due to mnemonic not matching the one in the unconsolidated wallet in the app state
-  export const MatchError = t.type({ tag: t.literal("matcherr") })
-  export type MatchError = t.TypeOf<typeof MatchError>
-
-  /** Factory function for `MatchError` response */
-  export function matchError(): MatchError {
-    return { tag: "matcherr" }
-  }
+export const validateMnemonicsErrors = {
+  INVALID_METHOD_PARAMS: t.literal("INVALID_METHOD_PARAMS"),
+  ID_GENERATION_ERROR: t.literal("ID_GENERATION_ERROR"),
+  INVALID_MNEMONICS: t.literal("INVALID_MNEMONICS"),
+  MISMATCHING_MNEMONICS: t.literal("MISMATCHING_MNEMONICS"),
+  UNCONSOLIDATED_UPDATE_FAILURE: t.literal("UNCONSOLIDATED_UPDATE_FAILURE")
 }
 
-export const ValidateMnemonicsResponse = t.taggedUnion("tag", [
-  ValidateMnemonicsResponses.Id,
-  ValidateMnemonicsResponses.Invalid,
-  ValidateMnemonicsResponses.MatchError
+export const ValidateMnemonicsErrors = t.union(Object.values(validateMnemonicsErrors))
+export type ValidateMnemonicsErrors = t.TypeOf<typeof ValidateMnemonicsErrors>
+
+export const ValidateMnemonicsError = t.type({
+  kind: t.literal("ERROR"),
+  error: ValidateMnemonicsErrors
+})
+export type ValidateMnemonicsError = t.TypeOf<typeof ValidateMnemonicsError>
+
+export const ValidateMnemonicsResponse = t.taggedUnion("kind", [
+  ValidateMnemonicsSuccess,
+  ValidateMnemonicsError,
 ], "ValidateMnemonicsResponse")
 export type ValidateMnemonicsResponse = t.TypeOf<typeof ValidateMnemonicsResponse>
 

--- a/app/main/api/handlers/validateMnemonics.ts
+++ b/app/main/api/handlers/validateMnemonics.ts
@@ -1,13 +1,19 @@
-import * as crypto from "crypto"
 import { config } from "app/common/config"
-import { asRuntimeType, Contexts } from "app/common/runtimeTypes"
+import { asObject, asRuntimeType, Contexts } from "app/common/runtimeTypes"
 import {
+  ValidateMnemonicsError,
+  validateMnemonicsErrors,
   ValidateMnemonicsParams,
-  ValidateMnemonicsResponse,
-  ValidateMnemonicsResponses
+  ValidateMnemonicsResponse
 } from "app/common/runtimeTypes/ipc/wallets"
-import { AppStateS } from "app/main/system"
+import { JsonSerializable } from "app/common/serializers"
+import { AppStateManager } from "app/main/appState"
 import * as mnemonic from "app/main/crypto/mnemonic"
+
+import { AppStateS } from "app/main/system"
+import { fanOut, inject, pick } from "app/main/utils/utils"
+import * as crypto from "crypto"
+import { LiteralType } from "io-ts"
 
 /**
  * Handler function for `validateMnemonics` method.
@@ -17,35 +23,115 @@ import * as mnemonic from "app/main/crypto/mnemonic"
  * If there is no `UnconsolidatedWallet` in the app state, it will create one with the mnemonics.
  * In both cases it will also generate a wallet ID and return it.
  */
-export default async function validateMnemonics({ appStateManager }: AppStateS, params: any) {
-  const { mnemonics } = asRuntimeType(params, ValidateMnemonicsParams, Contexts.IPC)
-  const id = generateId(mnemonics)
-  const unconsolidatedWallet = { mnemonics, id }
-  let response: ValidateMnemonicsResponse = ValidateMnemonicsResponses.id(id)
+export default async function validateMnemonics
+  ({ appStateManager }: AppStateS, params: any): Promise<JsonSerializable> {
 
-  if (mnemonic.isValid(mnemonics)) {
-    if (appStateManager.state.unconsolidatedWallet
-      && appStateManager.state.unconsolidatedWallet.mnemonics !== mnemonics) {
-      response = ValidateMnemonicsResponses.matchError()
-    } else {
-      appStateManager.update({ unconsolidatedWallet })
-    }
-  } else {
-    response = ValidateMnemonicsResponses.invalid()
-  }
+  // First of all, parse method parameters
+  return parseParams(params)
+    // Pick only the value of the mnemonics key from the handler parameters
+    .then(pick("mnemonics"))
+    // In parallel: validate mnemonic, check mnemonic against unconsolidated wallet and generate id
+    .then(fanOut([validateMnemonicsString, inject(matchMnemonics, appStateManager), generateId]))
+    // Update or insert unconsolidated wallet into app state
+    .then(inject(upsertUnconsolidated, appStateManager))
+    // The handler logic ends here. What follows is response building and encoding.
 
-  return ValidateMnemonicsResponse.encode(response)
+    // If everything was OK, return success
+    .then(buildSuccessResponse)
+    // If anything failed, return error
+    .catch(buildErrorResponse)
+    // Encode response
+    .then(encodeResponse)
 }
 
 /**
- * Generate a string id given a mnemonics string.
+ * Parse handler parameters as ValidateMnemonicsParams runtime type.
+ * @param params
  */
-export function generateId(mnemonics: string): string {
-  return crypto.pbkdf2Sync(
-    mnemonics,
-    config.mnemonicsIdGeneration.salt,
-    config.mnemonicsIdGeneration.hashIterations,
-    config.mnemonicsIdGeneration.keyByteLength,
-    config.mnemonicsIdGeneration.hashFunctionName
-  ).toString("hex")
+async function parseParams(params: any): Promise<ValidateMnemonicsParams> {
+  try { return asRuntimeType(params, ValidateMnemonicsParams, Contexts.IPC) }
+  catch { throw validateMnemonicsErrors.INVALID_METHOD_PARAMS }
+}
+
+/**
+ * Generate an id string given a mnemonics string.
+ * @param mnemonics
+ */
+function generateId(mnemonics: string): string {
+  try {
+    return crypto.pbkdf2Sync(
+      mnemonics,
+      config.mnemonicsIdGeneration.salt,
+      config.mnemonicsIdGeneration.hashIterations,
+      config.mnemonicsIdGeneration.keyByteLength,
+      config.mnemonicsIdGeneration.hashFunctionName
+    ).toString("hex")
+  } catch { throw validateMnemonicsErrors.ID_GENERATION_ERROR }
+}
+
+/**
+ * Validate if a string is a valid mnemonics string.
+ * @param mnemonics
+ */
+function validateMnemonicsString(mnemonics: string): string {
+  if (!mnemonic.isValid(mnemonics)) {
+    throw validateMnemonicsErrors.INVALID_MNEMONICS
+  }
+
+  return mnemonics
+}
+
+/**
+ * Check if received mnemonics match the mnemonics from a former unconsolidated wallet.
+ * @param mnemonics
+ * @param appStateManager
+ */
+function matchMnemonics(mnemonics: string, appStateManager: AppStateManager): string {
+  if (appStateManager.state.unconsolidatedWallet
+    && mnemonics !== appStateManager.state.unconsolidatedWallet.mnemonics) {
+    throw validateMnemonicsErrors.MISMATCHING_MNEMONICS
+  }
+
+  return mnemonics
+}
+
+/**
+ * Update or insert unconsolidated wallet into app state.
+ * @param appStateManager
+ * @param unconsolidated
+ */
+function upsertUnconsolidated
+  ([_, mnemonics, id]: Array<string>, appStateManager: AppStateManager): string {
+  try {
+    appStateManager.update({ unconsolidatedWallet: { id, mnemonics } })
+
+    return id
+  } catch {
+    throw validateMnemonicsErrors.UNCONSOLIDATED_UPDATE_FAILURE
+  }
+}
+
+/**
+ * Build success response.
+ * @param id
+ */
+function buildSuccessResponse(id: string): ValidateMnemonicsResponse {
+  return { kind: "SUCCESS", id }
+}
+
+/**
+ * Build error response.
+ * @param error
+ */
+function buildErrorResponse
+  (error: LiteralType<ValidateMnemonicsError["error"]>): ValidateMnemonicsResponse {
+  return { kind: "ERROR", error: error.value }
+}
+
+/**
+ * Encode final response as a serializable object.
+ * @param response
+ */
+function encodeResponse(response: ValidateMnemonicsResponse): JsonSerializable {
+  return asObject(response, ValidateMnemonicsResponse)
 }

--- a/app/main/utils/utils.ts
+++ b/app/main/utils/utils.ts
@@ -46,3 +46,12 @@ export function fanOut<I, O>(fns: Array<(arg: I) => O>) {
     fns.map(async (fn) => Promise.resolve(arg).then(fn))
   )
 }
+
+/**
+ * Picks a certain value by key from a map.
+ * This is a very simple yet quite convenient helper when used in promise chains.
+ * @param key
+ */
+export function pick<M, K extends keyof M>(key: K) {
+  return (map: M) => map[key]
+}

--- a/app/main/utils/utils.ts
+++ b/app/main/utils/utils.ts
@@ -32,3 +32,17 @@ export function kvSwap(obj: stringToNumber | numberToString | stringToString): a
 export function inject<T, U, V>(fn: (arg: T, injected: V) => U, injected: V) {
   return (arg: T): U => fn(arg, injected)
 }
+
+/**
+ * Converts a list of homogeneous functions into an asynchronous function that feeds a single input
+ * argument to all the listed functions and returns a list with the matching outputs.
+ * By "homogeneous" we mean that all the functions share the same contract: each of them accepts a
+ * single input argument of type I and return a single value of type O.
+ * TODO: with TS 3.x, we will be able to generalize fanOut() to accept non-homogeneous functions.
+ * @param fns
+ */
+export function fanOut<I, O>(fns: Array<(arg: I) => O>) {
+  return async (arg: I) => Promise.all(
+    fns.map(async (fn) => Promise.resolve(arg).then(fn))
+  )
+}


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This refactors #222 (`validateMnemonics` handler) as a promise chain.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
