### PR TITLE
fix(types): fix return type of createJsonAesLevelStorage function

### DIFF
--- a/app/main/storage/jsonAesLevel.ts
+++ b/app/main/storage/jsonAesLevel.ts
@@ -10,6 +10,7 @@ import { LevelPersister } from "app/main/persisters/level"
 import { jsonBufferSerializer } from "app/main/serializers/jsonBuffer"
 import { Storage } from "app/main/storage"
 import { ensurePath } from "app/main/storage/utils"
+import { JsonSerializable } from "app/common/serializers"
 
 const createAesSettings = (pbkdPassword: string): AesCipherSettings => ({
   ...defaultAesCipherSettings,
@@ -23,7 +24,9 @@ const createAesSettings = (pbkdPassword: string): AesCipherSettings => ({
  * @param {string} id
  * @returns Promise<Storage<Buffer, JsonSerializable, Buffer, Buffer>>
  */
-export async function createJsonAesLevelStorage(args: any) {
+export async function createJsonAesLevelStorage(
+  args: any
+): Promise<Storage<Buffer, JsonSerializable, Buffer, Buffer>> {
   try {
     const { id, password } = asRuntimeType(args, JsonAesLevelStorageParams)
 
@@ -45,7 +48,7 @@ export async function createJsonAesLevelStorage(args: any) {
 
     return new Storage(keyHasher, serializer, cipher, persister)
   } catch (err) {
-    return err
+    throw err
   }
 }
 


### PR DESCRIPTION
re #279

# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
The inferred return type of the function `createJsonAesLevelStorage` was not correct. Added explicit return type and fix catch behavior as stated in #279.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
