### PR TITLE
build(yarn): fix "yarn dev"

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build-renderer": "webpack --config config/webpack.renderer.js --progress --profile --colors",
     "build": "cross-env NODE_ENV=production yarn build-main && cross-env NODE_ENV=production yarn build-renderer",
     "build-dev": "cross-env NODE_ENV=development yarn build-main && cross-env NODE_ENV=development yarn build-renderer",
-    "dev": "yarn build-main && yarn hot-server --exec 'HOT=1 yarn start-electron'",
+    "dev": "yarn build-main && yarn hot-server --exec 'UPGRADE_EXTENSIONS=1 HOT=1 yarn start-electron'",
     "prestart": "yarn clean",
     "start": "yarn dev",
     "start-electron": "electron ./dist/main",


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful
`yarn dev` was partially broken because of old react/redux devtools.

`UPGRADE_EXTENSIONS=1 yarn dev` seems to solve the problem as it locally upgrades the react/redux developer extensions.

This commit fixes #291 by adding the `UPGRADE_EXTENSIONS=1` flag to the yarn dev task itself.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
