### PR TITLE
refactor(rt-types): rename importSeedError to match style guide

### DIFF
--- a/app/common/runtimeTypes/ipc/wallets.ts
+++ b/app/common/runtimeTypes/ipc/wallets.ts
@@ -36,7 +36,7 @@ export const importSeedErrors = {
 }
 
 export const ImportSeedErrors = t.union(Object.values(importSeedErrors))
-export type importSeedErrors = t.TypeOf<typeof ImportSeedErrors>
+export type ImportSeedErrors = t.TypeOf<typeof ImportSeedErrors>
 
 export const ImportSeedError = t.type({
   kind: t.literal("ERROR"),


### PR DESCRIPTION
- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

### Why this change is necessary and useful

Match variable naming style