### PR TITLE
refactor(login-form): services passed as props to loginForm container

### DIFF
--- a/app/renderer/actions/loginForm.ts
+++ b/app/renderer/actions/loginForm.ts
@@ -1,41 +1,9 @@
 import { actionCreator } from "./helpers"
 import * as Actions from "./actionNames"
-import * as api from "app/renderer/api"
 import { Wallet } from "app/common/runtimeTypes/storage/wallets"
-import { Services } from "app/renderer/services"
 import {
   SaveWalletAction,
 } from "./actionTypes"
-import { GetWalletResponse } from "app/common/runtimeTypes/ipc/wallets"
-
-// Function to assert a never value
-const assertNever = (x: never) => undefined
-
-// Function to return a function which allows a async conditional dispatch to unlock a wallet
-export const unlockWallet = (id: string, password: string) => {
-  return async (dispatch: any, getState: any, services: Services) => {
-    return new Promise((resolve, reject) => {
-      // Try to retrieve wallet from renderer API & dispatch wallet or error
-      api.getWallet(services.apiClient, id, password)
-        .then((walletResponse: GetWalletResponse) => {
-          // Check wallet response type
-          switch (walletResponse.kind) {
-            case "SUCCESS":
-              resolve(walletResponse.wallet)
-              break
-            case "ERROR":
-              reject(walletResponse.error)
-              break
-            default:
-              assertNever(walletResponse)
-          }
-        })
-        .catch((error) => {
-          reject(`UNLOCK_WALLET_UNEXPECTED_ERROR ${error.message}`)
-        })
-    })
-  }
-}
 
 // Action creator to save wallet
 export const saveWallet = (wallet: Wallet): SaveWalletAction => {

--- a/app/renderer/constants/urls.ts
+++ b/app/renderer/constants/urls.ts
@@ -1,5 +1,13 @@
+// Forms base URL
 export const FORMS = "/forms"
+
+// LoginForm URLS
 export const LOGIN = `${FORMS}/login`
+export const WALLET_SELECTION = `${LOGIN}`
+export const WALLET_PASSWORD_PROMPT = `${LOGIN}/password`
+
+// WalletForm URLS
 export const NEW_WALLET = `${FORMS}/wallet`
 
+// Main base URL
 export const MAIN = "/main"

--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -2,7 +2,7 @@ import { Wallets } from "app/common/runtimeTypes/storage/wallets"
 import * as api from "app/renderer/api"
 import * as React from "react"
 import { render } from "react-dom"
-import Root from "./ui/containers/Root"
+import Root from "app/renderer/ui/containers/Root"
 import "./ui/app.global.scss"
 
 const apiClient = new api.Client()
@@ -23,7 +23,7 @@ new Promise(async () => {
 
   // Root component rendering
   render(
-    <Root store={store} history={history} />,
+    <Root services={services} store={store} history={history} />,
     document.getElementById("root")
   )
 

--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -19,7 +19,7 @@ new Promise(async () => {
 
   // Configure and initialize Redux store
   const { configureStore, history } = require("./store/configureStore")
-  const store = configureStore({ wallets, wallet: false }, services)
+  const store = configureStore({ wallets, wallet: false })
 
   // Root component rendering
   render(

--- a/app/renderer/routes.tsx
+++ b/app/renderer/routes.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Store } from "redux"
-import { Route, Switch } from "react-router"
+import { Switch } from "react-router"
 
 import * as urls from "app/renderer/constants/urls"
 import { StoreState } from "app/renderer/store"
@@ -9,23 +9,26 @@ import Forms from "./ui/containers/Forms"
 import MainPage from "./ui/pages/main"
 import { ifWallets } from "./utils/guards"
 import { RedirectedRoute } from "./utils/redirectedRoute"
+import { PropsRoute } from "app/renderer/utils/propsRoute"
+import { Services } from "app/renderer/services"
 
-type RoutesProps = {
-  store: Store<StoreState>
+export type RoutesProps = {
+  store: Store<StoreState>,
+  services: Services
 }
 
 export default (props: RoutesProps) => {
-
   return (
     <App>
       <Switch>
-        <Route
-          // TODO: update with PATHS from Main container
+        <PropsRoute
           path={urls.MAIN}
-          render={mainRenderer}
+          ownProps={props}
+          component={MainPage}
         />
-        <Route
+        <PropsRoute
           path={urls.FORMS}
+          ownProps={props}
           component={Forms}
         />
         <RedirectedRoute
@@ -39,11 +42,4 @@ export default (props: RoutesProps) => {
       </Switch>
     </App>
   )
-}
-
-/**
- * Function to render the Main component (wallet unlocked)
- */
-const mainRenderer = (props: any) => {
-  return <MainPage {...props} />
 }

--- a/app/renderer/routes.tsx
+++ b/app/renderer/routes.tsx
@@ -1,14 +1,12 @@
 import * as React from "react"
 import { Store } from "redux"
-import { Switch } from "react-router"
+import { Switch, Route, Redirect } from "react-router"
 
 import * as urls from "app/renderer/constants/urls"
 import { StoreState } from "app/renderer/store"
 import App from "app/renderer/ui/containers/App"
-import Forms from "./ui/containers/Forms"
+import FormsContainer from "./ui/containers/Forms"
 import MainPage from "./ui/pages/main"
-import { ifWallets } from "./utils/guards"
-import { RedirectedRoute } from "./utils/redirectedRoute"
 import { PropsRoute } from "app/renderer/utils/propsRoute"
 import { Services } from "app/renderer/services"
 
@@ -29,17 +27,17 @@ export default (props: RoutesProps) => {
         <PropsRoute
           path={urls.FORMS}
           ownProps={props}
-          component={Forms}
+          component={FormsContainer}
         />
-        <RedirectedRoute
+        <Route
           exact={true}
           path="/"
-          guard={ifWallets(props.store)}
-          locationA={urls.LOGIN}
-          // TODO: update with PATHS from new wallet form container
-          locationB={urls.NEW_WALLET}
+          render={redirectToForms}
         />
       </Switch>
     </App>
   )
 }
+
+// Function to redirect to forms container
+const redirectToForms = () => <Redirect to={urls.FORMS}/>

--- a/app/renderer/store/configureStore.development.ts
+++ b/app/renderer/store/configureStore.development.ts
@@ -1,11 +1,10 @@
-import { Services } from "app/renderer/services"
 import { createStore, applyMiddleware, compose } from "redux"
-import thunk from "redux-thunk"
 import { createHashHistory } from "history"
 import { connectRouter, push, routerMiddleware } from "connected-react-router"
 import { createLogger } from "redux-logger"
+
 import rootReducer from "app/renderer/reducers"
-import { StoreState } from "./index"
+import { StoreState } from "app/renderer/store"
 
 declare const window: Window & {
   __REDUX_DEVTOOLS_EXTENSION_COMPOSE__?(a: any): void
@@ -49,9 +48,9 @@ const composeEnhancers: typeof compose =
  * @param initialState
  * @param services
  */
-function configureStore(initialState: StoreState, services: Services) {
+function configureStore(initialState: StoreState) {
 
-  const middlewares: Array<any> = [thunk.withExtraArgument(services), router]
+  const middlewares: Array<any> = [router]
   if (process.env.NODE_ENV === "development") {
     middlewares.push(logger)
   }

--- a/app/renderer/store/configureStore.production.ts
+++ b/app/renderer/store/configureStore.production.ts
@@ -1,10 +1,9 @@
-import rootReducer from "app/renderer/reducers"
-import { Services } from "app/renderer/services"
 import { connectRouter, routerMiddleware } from "connected-react-router"
 import createHashHistory from "history/createHashHistory"
 import { applyMiddleware, compose, createStore } from "redux"
-import thunk from "redux-thunk"
-import { StoreState } from "./index"
+
+import rootReducer from "app/renderer/reducers"
+import { StoreState } from "app/renderer/store"
 
 const history = createHashHistory()
 const router = routerMiddleware(history)
@@ -15,9 +14,9 @@ const router = routerMiddleware(history)
  * @param initialState
  * @param services
  */
-function configureStore(initialState: StoreState, services: Services) {
+function configureStore(initialState: StoreState) {
 
-  const middlewares = [thunk.withExtraArgument(services), router]
+  const middlewares = [router]
 
   const enhancer = compose(applyMiddleware.apply(undefined, middlewares))
 

--- a/app/renderer/ui/containers/Forms.tsx
+++ b/app/renderer/ui/containers/Forms.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Route, Switch, match } from "react-router"
+import { Switch } from "react-router"
 import { Store } from "redux"
 
 import * as urls from "app/renderer/constants/urls"
@@ -8,22 +8,35 @@ import {
   default as LoginFormContainer
 } from "app/renderer/ui/containers/LoginForm"
 import { SignupPage } from "app/renderer/ui/pages/signup"
+import { PropsRoute } from "app/renderer/utils/propsRoute"
+import { Services } from "app/renderer/services"
+import { ifWallets } from "app/renderer/utils/guards"
+import { RedirectedRoute } from "app/renderer/utils/redirectedRoute"
 
 export type Props = {
-  match: match<unknown>,
   store: Store<StoreState>
+  services: Services
 }
 
-export const Forms = ({ match, store }: Props) => (
+export const Forms = (props: Props) => (
   <div>
     <Switch>
-      <Route
+      <PropsRoute
         path={urls.LOGIN}
+        ownProps={props}
         component={LoginFormContainer}
       />
-      <Route
+      <PropsRoute
         path={urls.NEW_WALLET}
+        ownProps={props}
         component={SignupPage}
+      />
+      <RedirectedRoute
+        exact={true}
+        path={urls.FORMS}
+        guard={ifWallets(props.store)}
+        locationA={urls.LOGIN}
+        locationB={urls.NEW_WALLET}
       />
     </Switch>
   </div>

--- a/app/renderer/ui/containers/LoginForm.tsx
+++ b/app/renderer/ui/containers/LoginForm.tsx
@@ -16,14 +16,7 @@ import { Services } from "app/renderer/services"
 import * as api from "app/renderer/api"
 import { GetWalletResponse } from "app/common/runtimeTypes/ipc/wallets"
 
-/**
- * Paths of the routes that are used in this container
- * NOTE: root path MUST be "/forms/login"
- */
-export const PATHS = {
-  WALLET_SELECTION: "/forms/login",
-  WALLET_PASSWORD_PROMPT: "/forms/login/password",
-}
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * Props that match redux store state
@@ -119,7 +112,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
     await this.changeState({ id })
 
     // Dispatch action to go to next route
-    this.props.goTo(PATHS.WALLET_PASSWORD_PROMPT)
+    this.props.goTo(urls.WALLET_PASSWORD_PROMPT)
   }
 
   /**
@@ -128,8 +121,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
    */
   private walletSelectNewWallet = async () => {
     // Dispatch action to go to next route
-    // TODO: goTo("/forms/wallet") needs to be replaced by goTo(PATH.NEWWALLET)?
-    this.props.goTo("/forms/wallet")
+    this.props.goTo(urls.NEW_WALLET)
   }
 
   /**
@@ -158,8 +150,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
         this.props.actions.saveWallet(wallet)
 
         // Dispatch action to go to next route
-        // TODO: goTo("/main") needs to be replaced by goTo(MAIN_PATHS.MAIN)
-        this.props.goTo("/main")
+        this.props.goTo(urls.MAIN)
       })
       .catch(async (errorMessage: string) => {
         // Set error message in the state
@@ -227,11 +218,11 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
       <LoginForm unlockInProgress={this.state.unlockInProgress}>
         <Switch>
           <Route
-            path={PATHS.WALLET_PASSWORD_PROMPT}
+            path={urls.WALLET_PASSWORD_PROMPT}
             render={this.renderWalletPasswordRequest}
           />
           <Route
-            path={PATHS.WALLET_SELECTION}
+            path={urls.WALLET_SELECTION}
             render={this.renderWalletSelection}
           />
         </Switch>

--- a/app/renderer/ui/containers/Root.tsx
+++ b/app/renderer/ui/containers/Root.tsx
@@ -1,4 +1,3 @@
-import Routes from "app/renderer/routes"
 import { History } from "history"
 import * as React from "react"
 import { Provider } from "react-redux"
@@ -6,16 +5,20 @@ import { ConnectedRouter } from "connected-react-router"
 import { Store } from "redux"
 import { hot } from "react-hot-loader"
 
+import Routes from "app/renderer/routes"
+import { Services } from "app/renderer/services"
+
 interface IRootType {
   store: Store,
-  history: History
+  history: History,
+  services: Services
 }
 
-const Root = ({ store, history }: IRootType) => {
+const Root = ({ store, history, services }: IRootType) => {
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
-        <Routes store={store} />
+        <Routes services={services} store={store} />
       </ConnectedRouter>
     </Provider>
   )

--- a/app/renderer/utils/propsRoute.tsx
+++ b/app/renderer/utils/propsRoute.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { Route, RouteComponentProps } from "react-router"
+
+import { RoutesProps } from "app/renderer/routes"
+
+/**
+ * A PropsRoute component renders a Route in a path given by props.
+ *
+ * The render function of that Route will render a component given by props to PropsRoute
+ * and the props of that component will be a merge between RouteComponentProps and
+ * additional props (RoutesProps)
+ */
+export class PropsRoute extends React.Component<any> {
+  /**
+   * Function to render a component combining RouteComponentProps with RoutesProps
+   * as props
+   */
+  private withOwnProps = (A: typeof React.Component, routesProps: RoutesProps) =>
+    (props: RouteComponentProps<any>) => <A {...routesProps} {...props} />
+
+  /**
+   * PropsRoute render function.
+   */
+  public render() {
+    const { path, ownProps, component } = this.props
+
+    return <Route path={path} render={this.withOwnProps(component, ownProps)} />
+  }
+}


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

LoginForm container now receives services by props. This logic substitutes the previous use of the thunk middleware and it results in a clearer flow in the process of unlocking a wallet.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
