### PR TITLE
fix(handler): use "wallet" as the key to get wallet from AES storage

### DIFF
--- a/app/main/api/handlers/getWallet.ts
+++ b/app/main/api/handlers/getWallet.ts
@@ -3,12 +3,12 @@ import { inject } from "app/main/utils/utils"
 import { SubSystems } from "app/main/system"
 import { JsonSerializable } from "app/common/serializers/json"
 import { WalletInfo, Wallet } from "app/common/runtimeTypes/storage/wallets"
-import { Storage } from "app/main/storage"
 import {
   GetWalletParams, GetWalletResponse,
   GetWalletSuccess, getWalletErrors,
   buildGetWalletError
 } from "app/common/runtimeTypes/ipc/wallets"
+import { JsonAesLevelStorage } from "app/main/subsystems/jsonAesLevel"
 
 /**
  * Handler function for "getWallet" method.
@@ -87,7 +87,7 @@ function checkWalletInfo(params: GetWalletParams, system: SubSystems): GetWallet
  * @returns {Promise<{ storage: Storage<Buffer, JsonSerializable, Buffer, Buffer>, id: string }>}
  */
 async function replaceStorage(params: GetWalletParams, system: SubSystems)
-  : Promise<{ storage: Storage<Buffer, JsonSerializable, Buffer, Buffer>, id: string }> {
+  : Promise<{ storage: JsonAesLevelStorage, id: string }> {
   const { id, password } = params
 
   try {
@@ -107,11 +107,11 @@ async function replaceStorage(params: GetWalletParams, system: SubSystems)
  * @returns {Promise<Wallet>}
  */
 async function searchWallet(
-  { storage, id }: { storage: Storage<Buffer, JsonSerializable, Buffer, Buffer>, id: string }
+  { storage, id }: { storage: JsonAesLevelStorage, id: string }
 ): Promise<Wallet> {
-  const wallet = await storage.get(id)
-
   try {
+    const wallet = await storage.get("wallet")
+
     return asRuntimeType(wallet, Wallet)
   } catch (error) {
     throw getWalletErrors.INVALID_WALLET_TYPE

--- a/app/main/storage/jsonAesLevel.ts
+++ b/app/main/storage/jsonAesLevel.ts
@@ -10,7 +10,7 @@ import { LevelPersister } from "app/main/persisters/level"
 import { jsonBufferSerializer } from "app/main/serializers/jsonBuffer"
 import { Storage } from "app/main/storage"
 import { ensurePath } from "app/main/storage/utils"
-import { JsonSerializable } from "app/common/serializers"
+import { JsonAesLevelStorage } from "app/main/subsystems/jsonAesLevel"
 
 const createAesSettings = (pbkdPassword: string): AesCipherSettings => ({
   ...defaultAesCipherSettings,
@@ -25,7 +25,7 @@ const createAesSettings = (pbkdPassword: string): AesCipherSettings => ({
  * @returns Promise<Storage<Buffer, JsonSerializable, Buffer, Buffer>>
  */
 export async function createJsonAesLevelStorage(args: any)
-  : Promise<Storage<Buffer, JsonSerializable, Buffer, Buffer>> {
+  : Promise<JsonAesLevelStorage> {
   try {
     const { id, password } = asRuntimeType(args, JsonAesLevelStorageParams)
 


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The key used before was wrong, as it was the wallet id and not the string literal "wallet".
Additionally, some storage types have been simplified following the example of the encryptWallet
handler.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
