### PR TITLE
refactor(log): set production log level explicitly

### DIFF
--- a/app/main/index.ts
+++ b/app/main/index.ts
@@ -1,5 +1,6 @@
 const { app, ipcMain } = require("electron")
 
+import * as log from "electron-log"
 import { config } from "app/common/config"
 import { inDarwin, inDevelopment } from "app/common/env"
 import { Channels } from "app/main/ipc"
@@ -16,10 +17,10 @@ app.on("ready", startApplication)
 app.on("will-quit", stopApplication)
 
 if (inDevelopment) {
-  const log = require("electron-log")
   log.transports.console.level = log.transports.file.level = "debug"
   app.commandLine.appendSwitch("remote-debugging-port", "9222")
 } else {
+  log.transports.console.level = log.transports.file.level = "warn"
   const sourceMapSupport = require("source-map-support")
   sourceMapSupport.install()
 }

--- a/app/main/system.ts
+++ b/app/main/system.ts
@@ -52,8 +52,6 @@ const builders: Builders = {
   appStateManager: appStateSubSystem
 }
 
-log.debug(`builders: ${JSON.stringify(builders)}`)
-
 /**
  * Application wide system that starts all its components when started.
  * A system is just stateful object that supports Lifecycle protocol (it can be started and stopped)
@@ -80,6 +78,7 @@ export class System implements Lifecycle<SubSystems, Config> {
    * @param config
    */
   public async start(config?: Partial<Config>) {
+    log.debug(`builders: ${JSON.stringify(builders)}`)
     log.info("Starting system...")
 
     const promises: Array<Promise<SubSystems[keyof SubSystems]>> = Object.entries(builders)


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

Closes #375

This commit introduces changes that removes `debug` messages shown in
the console for production builds.


[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
