### PR TITLE
feat(button): blue buttons are now blue

### DIFF
--- a/app/renderer/ui/components/button/action/index.tsx
+++ b/app/renderer/ui/components/button/action/index.tsx
@@ -1,0 +1,34 @@
+import * as React from "react"
+
+import { Button } from "antd"
+
+const styles = require("./style.scss")
+
+export interface Iprops {
+  className?: string
+  onClick?: any
+  disabled?: boolean
+}
+
+/**
+ * Action button UI component
+ *
+ * @export
+ * @class ActionButton
+ * @extends {React.Component<Iprops>}
+ */
+
+export default class ActionButton extends React.Component<Iprops> {
+  // tslint:disable-next-line: completed-docs
+  public render() {
+    return (
+      <Button
+        className={`${styles.button} ${this.props.className}`}
+        onClick={this.props.onClick}
+        disabled={this.props.disabled}
+      >
+        {this.props.children}
+      </Button>
+    )
+  }
+}

--- a/app/renderer/ui/components/button/action/style.scss
+++ b/app/renderer/ui/components/button/action/style.scss
@@ -4,20 +4,32 @@
 
   .button {
     background: $button-action-background;
-    border: 0;
+    border: $button-action-border;
+    border-color: $button-action-border_color;
     border-radius: $button-action-border_radius;
     box-shadow: $button-action-shadow;
     color: $button-action-color;
     font-weight: $button-action-font_weight;
+    line-height: $button-action-line_height;
+    padding: $button-action-padding;
 
-    &:focus {
-      background: $button-action-background !important;
+    &:hover {
+      background: $button-action-background;
+      border-color: $button-action-border_color;
       color: $button-action-color;
     }
 
-    &:disabled {
+    &:focus {
+      background: $button-action-focus-background;
+      border-color: $button-action-focus-border_color;
+      color: $button-action-focus-color;
+    }
+
+    &:disabled,
+    &:disabled:hover {
       background: $button-action-disabled-background;
-      color: $button-action-color;
+      border-color: $button-action-disabled-border_color;
+      color: $button-action-disabled-color;
     }
   }
 }

--- a/app/renderer/ui/components/button/action/style.scss
+++ b/app/renderer/ui/components/button/action/style.scss
@@ -1,0 +1,23 @@
+:local {
+  @import "app/renderer/ui/fonts";
+  @import "app/renderer/ui/theme";
+
+  .button {
+    background: $button-action-background;
+    border: 0;
+    border-radius: $button-action-border_radius;
+    box-shadow: $button-action-shadow;
+    color: $button-action-color;
+    font-weight: $button-action-font_weight;
+
+    &:focus {
+      background: $button-action-background !important;
+      color: $button-action-color;
+    }
+
+    &:disabled {
+      background: $button-action-disabled-background;
+      color: $button-action-color;
+    }
+  }
+}

--- a/app/renderer/ui/components/button/index.tsx
+++ b/app/renderer/ui/components/button/index.tsx
@@ -2,10 +2,12 @@ import ButtonDefault from "./default/index"
 import ButtonLink from "./link/index"
 import ButtonNavigation from "./navigation/index"
 import ButtonOption from "./option/index"
+import ActionButton from "./action/index"
 
 export {
   ButtonDefault,
   ButtonLink,
   ButtonNavigation,
-  ButtonOption
+  ButtonOption,
+  ActionButton
 }

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -8,7 +8,7 @@ import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 import {
   paymentRequest,
 } from "app/renderer/ui/components/main/sections/wallet/MockData"
-import ActionButton from "app/renderer/ui/components/button/action"
+import { ActionButton } from "app/renderer/ui/components/button"
 
 const styles = require("./style.scss")
 

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -2,13 +2,13 @@ import * as React from "react"
 import Wrapper from "app/renderer/ui/components/wrapper"
 import List from "app/renderer/ui/components/list"
 import { InputDefault } from "app/renderer/ui/components/input"
-import { ButtonDefault } from "app/renderer/ui/components/button"
 import PaymentRequest from "app/renderer/ui/components/paymentRequest"
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 
 import {
   paymentRequest,
 } from "app/renderer/ui/components/main/sections/wallet/MockData"
+import ActionButton from "app/renderer/ui/components/button/action"
 
 const styles = require("./style.scss")
 
@@ -48,12 +48,12 @@ class TabReceive extends TabComponent<any> {
                 <InputDefault />
                 <label className={styles.label}> Expires </label>
                 <InputDefault />
-                <ButtonDefault
+                <ActionButton
                   className={styles.submit}
                   onClick={this.props.services.showUnimplementedMessage}
                 >
                   SAVE AND GENERATE ADDRESS
-                </ButtonDefault>
+                </ActionButton>
               </div>
               <div className={styles.qr}>
                 Your address and QR code will appear here once the payment request is saved

--- a/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 import Wrapper from "app/renderer/ui/components/wrapper"
 import { InputDefault } from "app/renderer/ui/components/input"
-import { ButtonDefault } from "app/renderer/ui/components/button"
+import ActionButton from "app/renderer/ui/components/button/action"
 
 const styles = require("./style.scss")
 
@@ -30,12 +30,12 @@ class TabSend extends TabComponent<any> {
           <InputDefault className={`${styles.input} ${styles["small-input"]}`} />
           <label className={styles.label}>Fee</label>
           <InputDefault className={`${styles.input} ${styles["small-input"]}`} />
-          <ButtonDefault
+          <ActionButton
             className={styles.submit}
             onClick={this.props.services.showUnimplementedMessage}
           >
             SIGN AND SEND
-          </ButtonDefault>
+          </ActionButton>
         </div>
       </Wrapper>
     )

--- a/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 import Wrapper from "app/renderer/ui/components/wrapper"
 import { InputDefault } from "app/renderer/ui/components/input"
-import ActionButton from "app/renderer/ui/components/button/action"
+import { ActionButton } from "app/renderer/ui/components/button"
 
 const styles = require("./style.scss")
 

--- a/app/renderer/ui/theme.scss
+++ b/app/renderer/ui/theme.scss
@@ -14,13 +14,25 @@ $button-link-color: $blue-6;
 $button-link-height: auto;
 $button-link-width: auto;
 
-$button-action-background: $blue-6;
-$button-action-border_radius: 2px;
-$button-action-shadow_color: rgba(0, 0, 0, 0.2);
-$button-action-shadow: 0 2px 5px 0 $button-action-shadow_color;
+$button-action-background-color: $blue-6;
+$button-action-background: $button-action-background-color;
+$button-action-border: 0;
+$button-action-border_radius: 4px;
+$button-action-border_color: $button-action-background-color;
 $button-action-color: $grey-1;
 $button-action-font_weight: 600;
-$button-action-disabled-background: $grey-4;
+$button-action-line_height: 1;
+$button-action-padding: 12px 15px 25px 15px;
+$button-action-shadow_color: rgba(0, 0, 0, 0.2);
+$button-action-shadow: 0 1px 5px 0 $button-action-shadow_color;
+$button-action-focus-background-color: $button-action-color;
+$button-action-focus-background: $button-action-focus-background-color;
+$button-action-focus-border_color: $button-action-focus-background-color;
+$button-action-focus-color: $button-action-background-color;
+$button-action-disabled-background_color: $grey-4;
+$button-action-disabled-background: $button-action-disabled-background_color;
+$button-action-disabled-border_color: $button-action-disabled-background_color;
+$button-action-disabled-color: $button-action-color;
 
 $card-default-shadow: 0 0 5px 0 $grey-3;
 

--- a/app/renderer/ui/theme.scss
+++ b/app/renderer/ui/theme.scss
@@ -14,6 +14,14 @@ $button-link-color: $blue-6;
 $button-link-height: auto;
 $button-link-width: auto;
 
+$button-action-background: $blue-6;
+$button-action-border_radius: 2px;
+$button-action-shadow_color: rgba(0, 0, 0, 0.2);
+$button-action-shadow: 0 2px 5px 0 $button-action-shadow_color;
+$button-action-color: $grey-1;
+$button-action-font_weight: 600;
+$button-action-disabled-background: $grey-4;
+
 $card-default-shadow: 0 0 5px 0 $grey-3;
 
 $input-big-border: 1px dashed $grey-8;


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Improve styling of buttons of the Wallet/Receive and Wallet/Send tabs (blue, with shadow, with possibility of being disabled...). Closes #347 

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
