### PR TITLE
fix(wallet-form): keep mnemonics in unconsolidated wallet until the encrypt wallet step

### DIFF
--- a/app/main/api/handlers/importSeed.ts
+++ b/app/main/api/handlers/importSeed.ts
@@ -153,8 +153,8 @@ function matchMnemonics(mnemonics: string, appStateManager: AppStateManager): st
 function upsertUnconsolidated
   (seed: Seed, appStateManager: AppStateManager) {
   try {
-    appStateManager.update({ unconsolidatedWallet: { seed } })
-
+    const unconsolidatedWallet = { ...appStateManager.state.unconsolidatedWallet, seed }
+    appStateManager.update({ unconsolidatedWallet })
   } catch {
     throw importSeedErrors.UNCONSOLIDATED_UPDATE_FAILURE
   }


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The removal of mnemonics from unconsolidated wallet in an intermediate step of the wallet form left an inconsistent app state when moving across the application. Mnemonics are now kept in the unconsolidated wallet until the encryptWallet step, where the whole unconsolidated wallet is removed from the app state.

fix #370


[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
