### PR TITLE
fix(wallet-form): remove match mnemonics check in importSeed handler in the backend 

### DIFF
--- a/app/renderer/ui/containers/LoginForm.tsx
+++ b/app/renderer/ui/containers/LoginForm.tsx
@@ -124,7 +124,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
    */
   private walletSelectNewWallet = async () => {
     // Dispatch action to go to next route
-    this.props.goTo(urls.NEW_WALLET)
+    this.props.goTo(urls.WALLET_SEED_TYPE_SELECTION)
   }
 
   /**

--- a/test/app/main/api/handlers/importSeed.spec.ts
+++ b/test/app/main/api/handlers/importSeed.spec.ts
@@ -53,14 +53,14 @@ describe("importSeed Handler", () => {
     expect(result).toMatchObject(error("INVALID_MNEMONICS"))
   })
 
-  it("should reject valid mnemonics not matching unconsolidated wallet", async () => {
+  it("should not reject valid mnemonics not matching unconsolidated wallet", async () => {
     const params = {
       kind: "mnemonics",
       mnemonics: "control enroll cancel obey join cup vault jazz brush pledge raven huge"
     }
     const result = await importSeed(system, params)
 
-    expect(result).toMatchObject(error("MISMATCHING_MNEMONICS"))
+    expect(result).toMatchObject({ kind: "SUCCESS" })
   })
 
   it("should import seed if mnemonics are fine", async () => {


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Mnemonics matching will be performed when needed (in the new seed logic) in the frontend. This allows us to reuse the `importSeed` handler to create a seed and to import a seed and fixes #373 

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
