### PR TITLE
fix(issue 364): display error messages in login

### DIFF
--- a/app/common/runtimeTypes/ipc/wallets.ts
+++ b/app/common/runtimeTypes/ipc/wallets.ts
@@ -65,9 +65,19 @@ export type GetWalletSuccess = t.TypeOf<typeof GetWalletSuccess>
 export const getWalletErrors = {
   INVALID_PARAMS_TYPE: t.literal("INVALID_PARAMS_TYPE"),
   INVALID_WALLET_TYPE: t.literal("INVALID_WALLET_TYPE"),
+  INVALID_PASSWORD: t.literal("INVALID_PASSWORD"),
   WALLET_NOT_FOUND: t.literal("WALLET_NOT_FOUND"),
   INSUFFICIENT_PERMISSIONS: t.literal("INSUFFICIENT_PERMISSIONS"),
   GENERIC_IPC_ERROR
+}
+
+export const getWalletErrorMessages = {
+  INVALID_PARAMS_TYPE: "Invalid Params Type",
+  INVALID_WALLET_TYPE: "Invalid Wallet Type",
+  INVALID_PASSWORD: "Invalid Password",
+  WALLET_NOT_FOUND: "Wallet Not Found",
+  INSUFFICIENT_PERMISSIONS: "Insufficient Permissions",
+  GENERIC_IPC_ERROR: "Unknown Error"
 }
 
 export const GetWalletErrors = t.union(Object.values(getWalletErrors))

--- a/app/common/runtimeTypes/ipc/wallets.ts
+++ b/app/common/runtimeTypes/ipc/wallets.ts
@@ -65,6 +65,7 @@ export type GetWalletSuccess = t.TypeOf<typeof GetWalletSuccess>
 export const getWalletErrors = {
   INVALID_PARAMS_TYPE: t.literal("INVALID_PARAMS_TYPE"),
   INVALID_WALLET_TYPE: t.literal("INVALID_WALLET_TYPE"),
+  CANNOT_ENCODE_WALLET: t.literal("CANNOT_ENCODE_WALLET"),
   INVALID_PASSWORD: t.literal("INVALID_PASSWORD"),
   WALLET_NOT_FOUND: t.literal("WALLET_NOT_FOUND"),
   INSUFFICIENT_PERMISSIONS: t.literal("INSUFFICIENT_PERMISSIONS"),
@@ -74,6 +75,7 @@ export const getWalletErrors = {
 export const getWalletErrorMessages = {
   INVALID_PARAMS_TYPE: "Invalid Params Type",
   INVALID_WALLET_TYPE: "Invalid Wallet Type",
+  CANNOT_ENCODE_WALLET: "Cannot Encode Wallet",
   INVALID_PASSWORD: "Invalid Password",
   WALLET_NOT_FOUND: "Wallet Not Found",
   INSUFFICIENT_PERMISSIONS: "Insufficient Permissions",

--- a/app/main/api/handlers/getWallet.ts
+++ b/app/main/api/handlers/getWallet.ts
@@ -132,7 +132,7 @@ function encodeResponse(response: GetWalletResponse): JsonSerializable {
   try {
     return asObject(response, GetWalletResponse)
   } catch (err) {
-    throw getWalletErrors.INVALID_WALLET_TYPE
+    throw getWalletErrors.CANNOT_ENCODE_WALLET
   }
 }
 

--- a/app/main/api/handlers/getWallet.ts
+++ b/app/main/api/handlers/getWallet.ts
@@ -91,8 +91,8 @@ async function replaceStorage(params: GetWalletParams, system: SubSystems)
   const { id, password } = params
 
   try {
-    const storage = await system.storageFactory({ id, password })
-    await system.walletStorage.replace(storage)
+    const storage = await system.walletStorage.replaceWith(
+      async () => system.storageFactory({ id, password }))
 
     return { storage, id }
   } catch (e) {
@@ -110,11 +110,15 @@ async function searchWallet(
   { storage, id }: { storage: JsonAesLevelStorage, id: string }
 ): Promise<Wallet> {
   try {
-    const wallet = await storage.get("wallet")
+    const data = await storage.get("wallet")
 
-    return asRuntimeType(wallet, Wallet)
+    try {
+      return asRuntimeType(data, Wallet)
+    } catch (error) {
+      throw getWalletErrors.INVALID_WALLET_TYPE
+    }
   } catch (error) {
-    throw getWalletErrors.INVALID_WALLET_TYPE
+    throw getWalletErrors.INVALID_PASSWORD
   }
 }
 

--- a/app/renderer/ui/containers/LoginForm.tsx
+++ b/app/renderer/ui/containers/LoginForm.tsx
@@ -14,7 +14,7 @@ import WalletSelection from "app/renderer/ui/components/loginForm/steps/walletSe
 import WalletPasswordRequest from "app/renderer/ui/components/loginForm/steps/walletPasswordRequest"
 import { Services } from "app/renderer/services"
 import * as api from "app/renderer/api"
-import { GetWalletResponse } from "app/common/runtimeTypes/ipc/wallets"
+import { getWalletErrorMessages, GetWalletResponse } from "app/common/runtimeTypes/ipc/wallets"
 
 import * as urls from "app/renderer/constants/urls"
 import { extendWalletData } from "app/renderer/prefilledWallet"
@@ -169,6 +169,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
    * @param services
    */
   private unlockWallet = async (id: string, password: string, services: Services) => {
+
     return new Promise<Wallet>((resolve, reject) => {
       // Try to retrieve wallet from renderer API & dispatch wallet or error
       api.getWallet(services.apiClient, id, password)
@@ -179,7 +180,7 @@ class LoginFormContainer extends React.Component<StateProps & DispatchProps & Ow
               resolve(walletResponse.wallet)
               break
             case "ERROR":
-              reject(walletResponse.error)
+              reject(getWalletErrorMessages[walletResponse.error] || "Unknown error")
               break
             default:
               assertNever(walletResponse)


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [X] I have read and understood [CODE_OF_CONDUCT][code] document.
- [X] I have read and understood [CONTRIBUTING][cont] document.
- [X] I have read and understood [STYLEGUIDE][style] document.
- [X] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [X] My code is formatted and is accepted by `yarn fmt`.
- [X] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

- add a new `replaceWith` method to the storage that will close the current storage before creating a new one
- show error messages instead of the error type in the login form

Fixes #364

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
