### PR TITLE
feat(container): move main section router to main container

### DIFF
--- a/app/renderer/constants/urls.ts
+++ b/app/renderer/constants/urls.ts
@@ -1,7 +1,7 @@
 // Forms base URL
 export const FORMS = "/forms"
 
-// WalletForm URLS
+// WalletForm URLs
 export const NEW_WALLET = `${FORMS}/wallet`
 export const WELCOME = `${NEW_WALLET}/welcome`
 export const WALLET_SEED_TYPE_SELECTION = `${NEW_WALLET}/wallet-seed-type-selection`
@@ -11,10 +11,27 @@ export const WALLET_ENCRYPTION_PASSWORD = `${NEW_WALLET}/wallet-encryption-passw
 export const WALLET_IMPORT_MNEMONICS = `${NEW_WALLET}/wallet-import-mnemonics`
 export const WALLET_IMPORT_XPRV = `${NEW_WALLET}/wallet-import-xprv`
 
-// LoginForm URLS
+// LoginForm URLs
 export const LOGIN = `${FORMS}/login`
 export const WALLET_SELECTION = `${LOGIN}`
 export const WALLET_PASSWORD_PROMPT = `${LOGIN}/password`
 
-// Main base URL
+// Main URLs
 export const MAIN = "/main"
+export const WALLET_SECTION = `${MAIN}/wallet`
+export const SMART_CONTRACTS_SECTION = `${MAIN}/smartcontracts`
+export const ATTESTATIONS_SECTION = `${MAIN}/attestations`
+export const BLOCK_EXPLORER_SECTION = `${MAIN}/blockexplorer`
+export const COMMUNITY_SECTION = `${MAIN}/community`
+
+// Main-WalletSection URLs
+export const TRANSACTIONS_TAB = `${WALLET_SECTION}/transactions`
+export const COINS_TAB = `${WALLET_SECTION}/coins`
+export const SEND_TAB = `${WALLET_SECTION}/send`
+export const RECEIVE_TAB = `${WALLET_SECTION}/receive`
+
+// Main-SmartContracts URLs
+export const MY_CONTRACTS_TAB = `${SMART_CONTRACTS_SECTION}/mycontracts`
+export const EASY_COMPOSER_TAB = `${SMART_CONTRACTS_SECTION}/easycomposer`
+export const PROEDITOR_TAB = `${SMART_CONTRACTS_SECTION}/proeditor`
+export const MARKETPLACE_TAB = `${SMART_CONTRACTS_SECTION}/marketplace`

--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -6,6 +6,7 @@ import { render } from "react-dom"
 import Root from "app/renderer/ui/containers/Root"
 import "./ui/app.global.scss"
 import { UnimplementedMessage } from "app/renderer/ui/components/unimplementedMessage"
+import { Services } from "app/renderer/services"
 const apiClient = new api.Client()
 
 /**
@@ -26,7 +27,7 @@ new Promise(async () => {
 
   // This object holds resources that are shared among different parts of the app and unifies
   // dependency injection.
-  const services = {
+  const services: Services = {
     apiClient,
     showUnimplementedMessage
   }

--- a/app/renderer/routes.tsx
+++ b/app/renderer/routes.tsx
@@ -6,7 +6,7 @@ import * as urls from "app/renderer/constants/urls"
 import { StoreState } from "app/renderer/store"
 import App from "app/renderer/ui/containers/App"
 import FormsContainer from "./ui/containers/Forms"
-import MainPage from "./ui/components/main"
+import MainContainer from "./ui/containers/Main"
 import { PropsRoute } from "app/renderer/utils/propsRoute"
 import { Services } from "app/renderer/services"
 
@@ -22,7 +22,7 @@ export default (props: RoutesProps) => {
         <PropsRoute
           path={urls.MAIN}
           ownProps={props}
-          component={MainPage}
+          component={MainContainer}
         />
         <PropsRoute
           path={urls.FORMS}

--- a/app/renderer/services.ts
+++ b/app/renderer/services.ts
@@ -1,5 +1,9 @@
 import { Client } from "app/renderer/api"
 
 export type Services = {
-  apiClient: Client
+  // Client used to communicate with backend via IPC
+  apiClient: Client,
+
+  // Method to show a message for a not-yet-implemented functionality
+  showUnimplementedMessage: () => void
 }

--- a/app/renderer/ui/components/commonTypes.ts
+++ b/app/renderer/ui/components/commonTypes.ts
@@ -10,5 +10,5 @@ export type TopBarProps = {
 export type TopBarLinkProps = {
   key: string
   caption: string
-  link: string
+  path: string
 }

--- a/app/renderer/ui/components/main/index.tsx
+++ b/app/renderer/ui/components/main/index.tsx
@@ -20,10 +20,7 @@ const sections: Array<SectionInfo> = [
 // Props passed to the sidebar component
 const sidebarProps = {
   className: styles.sidebar,
-  linksProps: sections.map((section) => ({
-    ...section,
-    link: `${section.link}`
-  }))
+  linksProps: sections
 }
 
 // Own props for the component

--- a/app/renderer/ui/components/main/index.tsx
+++ b/app/renderer/ui/components/main/index.tsx
@@ -1,85 +1,55 @@
 import React = require("react")
-import { RouteComponentProps, Switch } from "react-router"
 
 import Sidebar from "app/renderer/ui/components/sidebar"
+import { SectionInfo } from "app/renderer/ui/components/main/sections"
+
 import SmartContractsSection from "app/renderer/ui/components/main/sections/smartContracts"
 import AttestationsSection from "app/renderer/ui/components/main/sections/attestations"
 import BlockExplorerSection from "app/renderer/ui/components/main/sections/blockExplorer"
 import CommunitySection from "app/renderer/ui/components/main/sections/community"
 import WalletSection from "app/renderer/ui/components/main/sections/wallet"
-
-import { SectionInfo } from "app/renderer/ui/components/main/sections"
-import { PropsRoute } from "app/renderer/utils/propsRoute"
+import { Services } from "app/renderer/services"
 
 const styles = require("app/renderer/ui/components/main/style.scss")
 
+// Array of info for all sections in main page
 const sections: Array<SectionInfo> = [
   WalletSection, SmartContractsSection, AttestationsSection, BlockExplorerSection, CommunitySection
 ]
 
+// Props passed to the sidebar component
 const sidebarProps = {
   className: styles.sidebar,
   linksProps: sections.map((section) => ({
     ...section,
-    link: `/main/${section.key}`
+    link: `${section.link}`
   }))
 }
 
-interface Props {
-  services: {
-    showUnimplementedMessage: Function
-  }
+// Own props for the component
+interface OwnProps {
+  locationPathname: string,
+  services: Services
 }
+
 /**
- * MainPage page component
+ * MainPage UI component
  *
  * @export
  * @class MainPage
- * @extends {React.Component<RouteComponentProps<any>, void>}
+ * @extends {React.Component<OwnProps>}
  */
-export class MainPage extends React.Component<RouteComponentProps<any> & Props> {
+export class MainPage extends React.Component<OwnProps> {
   /** render */
   // tslint:disable-next-line:prefer-function-over-method
   public render() {
     return (
       <div className={styles.layout}>
-        <Sidebar {...sidebarProps} pathName={this.props.location.pathname} />
+        <Sidebar {...sidebarProps} pathName={this.props.locationPathname}/>
         <div className={styles.main}>
-          <Switch>
-            <PropsRoute
-              path="/main/wallet"
-              ownProps={this.props}
-              component={WalletSection.component}
-            />
-            <PropsRoute
-              path="/main/smartcontracts"
-              ownProps={this.props}
-              component={SmartContractsSection.component}
-            />
-            <PropsRoute
-              path="/main/attestations"
-              ownProps={this.props}
-              component={AttestationsSection.component}
-            />
-            <PropsRoute
-              path="/main/blockexplorer"
-              ownProps={this.props}
-              component={BlockExplorerSection.component}
-            />
-            <PropsRoute
-              path="/main/community"
-              ownProps={this.props}
-              component={CommunitySection.component}
-            />
-            <PropsRoute
-              path="/"
-              ownProps={this.props}
-              component={WalletSection.component}
-            />
-          </Switch>
+        {this.props.children}
         </div>
       </div>
     )
   }
 }
-export default MainPage

--- a/app/renderer/ui/components/main/sections/attestations/index.tsx
+++ b/app/renderer/ui/components/main/sections/attestations/index.tsx
@@ -25,7 +25,7 @@ class Attestations extends React.Component<SectionProps> {
 const AttestationsSection: SectionInfo = {
   key: "attestations",
   caption: "Attestations",
-  link: urls.ATTESTATIONS_SECTION,
+  path: urls.ATTESTATIONS_SECTION,
   component: Attestations,
   icon: "eye"
 }

--- a/app/renderer/ui/components/main/sections/attestations/index.tsx
+++ b/app/renderer/ui/components/main/sections/attestations/index.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+
 import { SectionInfo, SectionProps } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * Attestations UI component
@@ -23,6 +25,7 @@ class Attestations extends React.Component<SectionProps> {
 const AttestationsSection: SectionInfo = {
   key: "attestations",
   caption: "Attestations",
+  link: urls.ATTESTATIONS_SECTION,
   component: Attestations,
   icon: "eye"
 }

--- a/app/renderer/ui/components/main/sections/blockExplorer/index.tsx
+++ b/app/renderer/ui/components/main/sections/blockExplorer/index.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+
 import { SectionInfo, SectionProps } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * BlockExplorer UI component
@@ -23,6 +25,7 @@ export class BlockExplorer extends React.Component<SectionProps> {
 const BlockExplorerSection: SectionInfo = {
   key: "blockexplorer",
   caption: "Block Explorer",
+  link: urls.BLOCK_EXPLORER_SECTION,
   component: BlockExplorer,
   icon: "square"
 }

--- a/app/renderer/ui/components/main/sections/blockExplorer/index.tsx
+++ b/app/renderer/ui/components/main/sections/blockExplorer/index.tsx
@@ -25,7 +25,7 @@ export class BlockExplorer extends React.Component<SectionProps> {
 const BlockExplorerSection: SectionInfo = {
   key: "blockexplorer",
   caption: "Block Explorer",
-  link: urls.BLOCK_EXPLORER_SECTION,
+  path: urls.BLOCK_EXPLORER_SECTION,
   component: BlockExplorer,
   icon: "square"
 }

--- a/app/renderer/ui/components/main/sections/community/index.tsx
+++ b/app/renderer/ui/components/main/sections/community/index.tsx
@@ -25,7 +25,7 @@ export class Community extends React.Component<SectionProps> {
 const CommunitySection: SectionInfo = {
   key: "community",
   caption: "Community",
-  link: urls.COMMUNITY_SECTION,
+  path: urls.COMMUNITY_SECTION,
   component: Community,
   icon: "users"
 }

--- a/app/renderer/ui/components/main/sections/community/index.tsx
+++ b/app/renderer/ui/components/main/sections/community/index.tsx
@@ -1,5 +1,7 @@
 import * as React from "react"
+
 import { SectionInfo, SectionProps } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * Community UI component
@@ -23,6 +25,7 @@ export class Community extends React.Component<SectionProps> {
 const CommunitySection: SectionInfo = {
   key: "community",
   caption: "Community",
+  link: urls.COMMUNITY_SECTION,
   component: Community,
   icon: "users"
 }

--- a/app/renderer/ui/components/main/sections/index.tsx
+++ b/app/renderer/ui/components/main/sections/index.tsx
@@ -52,7 +52,7 @@ export class SectionComponent<Props> extends React.Component<SectionProps & Path
 export interface SectionInfo {
   key: string
   caption: string
-  link: string
+  path: string
   icon?: string
   component: React.ComponentClass<SectionProps>
 }
@@ -87,6 +87,6 @@ export class TabComponent<Props> extends React.Component<TabProps & PathNameProp
 export interface TabInfo {
   key: string
   caption: string
-  link: string
+  path: string
   component: React.ComponentClass<TabProps>
 }

--- a/app/renderer/ui/components/main/sections/index.tsx
+++ b/app/renderer/ui/components/main/sections/index.tsx
@@ -52,6 +52,7 @@ export class SectionComponent<Props> extends React.Component<SectionProps & Path
 export interface SectionInfo {
   key: string
   caption: string
+  link: string
   icon?: string
   component: React.ComponentClass<SectionProps>
 }
@@ -86,5 +87,6 @@ export class TabComponent<Props> extends React.Component<TabProps & PathNameProp
 export interface TabInfo {
   key: string
   caption: string
+  link: string
   component: React.ComponentClass<TabProps>
 }

--- a/app/renderer/ui/components/main/sections/smartContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/index.tsx
@@ -1,5 +1,4 @@
 import * as React from "react"
-import { Route, Switch } from "react-router"
 
 import { TabMyContracts, TabEasyComposer, TabProEditor, TabMarketplace } from "./tabs"
 import TopBar from "app/renderer/ui/components/topBar/index"
@@ -38,15 +37,9 @@ class SmartContracts extends React.Component<SmartContractsProps> {
     return (
       <>
         <TopBar className={mainStyles["top-bar"]} pathName="" linksProps={topBarlinkProps} />
-        <Switch>
-          <div className={styles.layout}>
-            <Route path={urls.MY_CONTRACTS_TAB} component={TabMyContracts.component} />
-            <Route path={urls.EASY_COMPOSER_TAB} component={TabEasyComposer.component} />
-            <Route path={urls.PROEDITOR_TAB} component={TabProEditor.component} />
-            <Route path={urls.MARKETPLACE_TAB} component={TabMarketplace.component} />
-            <Route path="/" component={TabMyContracts.component} />
-          </div>
-        </Switch>
+        <div className={styles.layout}>
+          {this.props.children}
+        </div>
       </>
     )
   }

--- a/app/renderer/ui/components/main/sections/smartContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/index.tsx
@@ -6,6 +6,8 @@ import TopBar from "app/renderer/ui/components/topBar/index"
 import { TopBarLinkProps } from "app/renderer/ui/components/commonTypes"
 import { SectionInfo } from "app/renderer/ui/components/main/sections"
 
+import * as urls from "app/renderer/constants/urls"
+
 const mainStyles = require("app/renderer/ui/components/main/style.scss")
 const styles = require("./style.scss")
 
@@ -29,7 +31,7 @@ class SmartContracts extends React.Component<SmartContractsProps> {
       {
         key: tab.key,
         caption: tab.caption,
-        link: `/main/smartcontracts/${tab.key}`
+        link: `${tab.link}`
       }
     ))
 
@@ -38,14 +40,11 @@ class SmartContracts extends React.Component<SmartContractsProps> {
         <TopBar className={mainStyles["top-bar"]} pathName="" linksProps={topBarlinkProps} />
         <Switch>
           <div className={styles.layout}>
-            <Route
-              path="/main/smartcontracts/mycontracts"
-              component={TabEasyComposer.component}
-            />
-            <Route path="/main/smartcontracts/easycomposer" component={TabMyContracts.component} />
-            <Route path="/main/smartcontracts/proeditor" component={TabProEditor.component} />
-            <Route path="/main/smartcontracts/marketplace" component={TabMarketplace.component} />
-            <Route path="/main" component={TabMyContracts.component} />
+            <Route path={urls.MY_CONTRACTS_TAB} component={TabMyContracts.component} />
+            <Route path={urls.EASY_COMPOSER_TAB} component={TabEasyComposer.component} />
+            <Route path={urls.PROEDITOR_TAB} component={TabProEditor.component} />
+            <Route path={urls.MARKETPLACE_TAB} component={TabMarketplace.component} />
+            <Route path="/" component={TabMyContracts.component} />
           </div>
         </Switch>
       </>
@@ -56,6 +55,7 @@ class SmartContracts extends React.Component<SmartContractsProps> {
 const SmartContractsSection: SectionInfo = {
   key: "smartcontracts",
   caption: "Smart Contracts",
+  link: urls.SMART_CONTRACTS_SECTION,
   component: SmartContracts,
   icon: "code"
 }

--- a/app/renderer/ui/components/main/sections/smartContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/index.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { TabMyContracts, TabEasyComposer, TabProEditor, TabMarketplace } from "./tabs"
 import TopBar from "app/renderer/ui/components/topBar/index"
 import { TopBarLinkProps } from "app/renderer/ui/components/commonTypes"
-import { SectionInfo } from "app/renderer/ui/components/main/sections"
+import { SectionInfo, TabInfo } from "app/renderer/ui/components/main/sections"
 
 import * as urls from "app/renderer/constants/urls"
 
@@ -25,12 +25,12 @@ class SmartContracts extends React.Component<SmartContractsProps> {
 
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
-    const tabs = [TabMyContracts, TabEasyComposer, TabProEditor, TabMarketplace]
+    const tabs: Array<TabInfo> = [TabMyContracts, TabEasyComposer, TabProEditor, TabMarketplace]
     const topBarlinkProps: Array<TopBarLinkProps> = tabs.map(tab => (
       {
         key: tab.key,
         caption: tab.caption,
-        link: `${tab.link}`
+        path: `${tab.path}`
       }
     ))
 
@@ -48,7 +48,7 @@ class SmartContracts extends React.Component<SmartContractsProps> {
 const SmartContractsSection: SectionInfo = {
   key: "smartcontracts",
   caption: "Smart Contracts",
-  link: urls.SMART_CONTRACTS_SECTION,
+  path: urls.SMART_CONTRACTS_SECTION,
   component: SmartContracts,
   icon: "code"
 }

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/easyComposer/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/easyComposer/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * EasyComposer component
@@ -22,6 +23,7 @@ class EasyComposer extends TabComponent<any> {
 const EasyComposerTab: TabInfo = {
   key: "easycomposer",
   caption: "easy composer",
+  link: urls.EASY_COMPOSER_TAB,
   component: EasyComposer
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/easyComposer/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/easyComposer/index.tsx
@@ -23,7 +23,7 @@ class EasyComposer extends TabComponent<any> {
 const EasyComposerTab: TabInfo = {
   key: "easycomposer",
   caption: "easy composer",
-  link: urls.EASY_COMPOSER_TAB,
+  path: urls.EASY_COMPOSER_TAB,
   component: EasyComposer
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/marketplace/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/marketplace/index.tsx
@@ -52,7 +52,7 @@ class MarketPlace extends TabComponent<any> {
 const MarketPlaceTab: TabInfo = {
   key: "MarketPlace",
   caption: "Marketplace",
-  link: urls.MARKETPLACE_TAB,
+  path: urls.MARKETPLACE_TAB,
   component: MarketPlace
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/marketplace/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/marketplace/index.tsx
@@ -4,6 +4,8 @@ import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 import { CardMarketplaceProduct } from "app/renderer/ui/components/card"
 import { marketplaceProducts } from "app/renderer/ui/components/main/sections/wallet/MockData"
 
+import * as urls from "app/renderer/constants/urls"
+
 const styles = require("./style.scss")
 
 export interface Iprops {
@@ -50,6 +52,7 @@ class MarketPlace extends TabComponent<any> {
 const MarketPlaceTab: TabInfo = {
   key: "MarketPlace",
   caption: "Marketplace",
+  link: urls.MARKETPLACE_TAB,
   component: MarketPlace
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/myContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/myContracts/index.tsx
@@ -23,7 +23,7 @@ class MyContracts extends TabComponent<any> {
 const MyContractsTab: TabInfo = {
   key: "mycontracts",
   caption: "My contracts",
-  link: urls.MY_CONTRACTS_TAB,
+  path: urls.MY_CONTRACTS_TAB,
   component: MyContracts
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/myContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/myContracts/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * MyContracts component
@@ -19,10 +20,11 @@ class MyContracts extends TabComponent<any> {
   }
 }
 
-const TransactionsTab: TabInfo = {
+const MyContractsTab: TabInfo = {
   key: "mycontracts",
   caption: "My contracts",
+  link: urls.MY_CONTRACTS_TAB,
   component: MyContracts
 }
 
-export default TransactionsTab
+export default MyContractsTab

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/proEditor/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/proEditor/index.tsx
@@ -23,7 +23,7 @@ class TabProEditor extends TabComponent<any> {
 const ProEditorTab: TabInfo = {
   key: "proEditor",
   caption: "PRO Editor",
-  link: urls.PROEDITOR_TAB,
+  path: urls.PROEDITOR_TAB,
   component: TabProEditor
 }
 

--- a/app/renderer/ui/components/main/sections/smartContracts/tabs/proEditor/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/tabs/proEditor/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * TabProEditor component
@@ -19,10 +20,11 @@ class TabProEditor extends TabComponent<any> {
   }
 }
 
-const TransactionsTab: TabInfo = {
+const ProEditorTab: TabInfo = {
   key: "proEditor",
   caption: "PRO Editor",
+  link: urls.PROEDITOR_TAB,
   component: TabProEditor
 }
 
-export default TransactionsTab
+export default ProEditorTab

--- a/app/renderer/ui/components/main/sections/wallet/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/index.tsx
@@ -7,6 +7,8 @@ import TopBar from "app/renderer/ui/components/topBar/index"
 import { TopBarLinkProps } from "app/renderer/ui/components/commonTypes"
 import { PropsRoute } from "app/renderer/utils/propsRoute"
 
+import * as urls from "app/renderer/constants/urls"
+
 const styles = require("./style.scss")
 const mainStyles = require("app/renderer/ui/components/main/style.scss")
 
@@ -26,7 +28,7 @@ class Wallet extends React.Component<WalletProps> {
       {
         caption: tab.caption,
         key: tab.key,
-        link: `/main/wallet/${tab.key}`
+        link: `${tab.link}`
       }
     ))
 
@@ -36,22 +38,22 @@ class Wallet extends React.Component<WalletProps> {
         <div className={styles.layout}>
           <Switch>
             <PropsRoute
-              path="/main/wallet/transactions"
+              path={urls.TRANSACTIONS_TAB}
               ownProps={this.props}
               component={TabTransactions.component}
             />
             <PropsRoute
-              path="/main/wallet/coins"
+              path={urls.COINS_TAB}
               ownProps={this.props}
               component={TabCoins.component}
             />
             <PropsRoute
-              path="/main/wallet/send"
+              path={urls.SEND_TAB}
               ownProps={this.props}
               component={TabSend.component}
             />
             <PropsRoute
-              path="/main/wallet/receive"
+              path={urls.RECEIVE_TAB}
               ownProps={this.props}
               component={TabReceive.component}
             />
@@ -70,6 +72,7 @@ class Wallet extends React.Component<WalletProps> {
 const WalletSection: SectionInfo = {
   key: "wallet",
   caption: "Wallet",
+  link: urls.WALLET_SECTION,
   icon: "book",
   component: Wallet
 }

--- a/app/renderer/ui/components/main/sections/wallet/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/index.tsx
@@ -1,11 +1,9 @@
 import * as React from "react"
-import { Switch } from "react-router"
 
 import { SectionInfo } from "app/renderer/ui/components/main/sections"
 import { TabCoins, TabReceive, TabSend, TabTransactions } from "./tabs"
 import TopBar from "app/renderer/ui/components/topBar/index"
 import { TopBarLinkProps } from "app/renderer/ui/components/commonTypes"
-import { PropsRoute } from "app/renderer/utils/propsRoute"
 
 import * as urls from "app/renderer/constants/urls"
 
@@ -36,33 +34,7 @@ class Wallet extends React.Component<WalletProps> {
       <>
         <TopBar className={mainStyles["top-bar"]} pathName="" linksProps={topBarlinkProps} />
         <div className={styles.layout}>
-          <Switch>
-            <PropsRoute
-              path={urls.TRANSACTIONS_TAB}
-              ownProps={this.props}
-              component={TabTransactions.component}
-            />
-            <PropsRoute
-              path={urls.COINS_TAB}
-              ownProps={this.props}
-              component={TabCoins.component}
-            />
-            <PropsRoute
-              path={urls.SEND_TAB}
-              ownProps={this.props}
-              component={TabSend.component}
-            />
-            <PropsRoute
-              path={urls.RECEIVE_TAB}
-              ownProps={this.props}
-              component={TabReceive.component}
-            />
-            <PropsRoute
-              path="/"
-              ownProps={this.props}
-              component={TabTransactions.component}
-            />
-          </Switch>
+          {this.props.children}
         </div>
       </>
     )

--- a/app/renderer/ui/components/main/sections/wallet/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { SectionInfo } from "app/renderer/ui/components/main/sections"
+import { SectionInfo, TabInfo } from "app/renderer/ui/components/main/sections"
 import { TabCoins, TabReceive, TabSend, TabTransactions } from "./tabs"
 import TopBar from "app/renderer/ui/components/topBar/index"
 import { TopBarLinkProps } from "app/renderer/ui/components/commonTypes"
@@ -21,12 +21,12 @@ interface WalletProps { }
 class Wallet extends React.Component<WalletProps> {
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
-    const tabs = [TabTransactions, TabReceive, TabSend, TabCoins]
+    const tabs: Array<TabInfo> = [TabTransactions, TabReceive, TabSend, TabCoins]
     const topBarlinkProps: Array<TopBarLinkProps> = tabs.map(tab => (
       {
         caption: tab.caption,
         key: tab.key,
-        link: `${tab.link}`
+        path: `${tab.path}`
       }
     ))
 
@@ -44,7 +44,7 @@ class Wallet extends React.Component<WalletProps> {
 const WalletSection: SectionInfo = {
   key: "wallet",
   caption: "Wallet",
-  link: urls.WALLET_SECTION,
+  path: urls.WALLET_SECTION,
   icon: "book",
   component: Wallet
 }

--- a/app/renderer/ui/components/main/sections/wallet/tabs/coins/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/coins/index.tsx
@@ -23,7 +23,7 @@ class TabCoins extends TabComponent<any> {
 const CoinsTab: TabInfo = {
   key: "coins",
   caption: "Coins",
-  link: urls.COINS_TAB,
+  path: urls.COINS_TAB,
   component: TabCoins
 }
 

--- a/app/renderer/ui/components/main/sections/wallet/tabs/coins/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/coins/index.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
+import * as urls from "app/renderer/constants/urls"
 
 /**
  * TabCoins component
@@ -19,10 +20,11 @@ class TabCoins extends TabComponent<any> {
   }
 }
 
-const TransactionsTab: TabInfo = {
+const CoinsTab: TabInfo = {
   key: "coins",
   caption: "Coins",
+  link: urls.COINS_TAB,
   component: TabCoins
 }
 
-export default TransactionsTab
+export default CoinsTab

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -95,7 +95,7 @@ class TabReceive extends TabComponent<any> {
 const ReceiveTab: TabInfo = {
   key: "receive",
   caption: "Receive",
-  link: urls.RECEIVE_TAB,
+  path: urls.RECEIVE_TAB,
   component: TabReceive
 }
 

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -5,6 +5,8 @@ import { InputDefault } from "app/renderer/ui/components/input"
 import PaymentRequest from "app/renderer/ui/components/paymentRequest"
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 
+import * as urls from "app/renderer/constants/urls"
+
 import {
   paymentRequest,
 } from "app/renderer/ui/components/main/sections/wallet/MockData"
@@ -90,10 +92,11 @@ class TabReceive extends TabComponent<any> {
   }
 }
 
-const TransactionsTab: TabInfo = {
+const ReceiveTab: TabInfo = {
   key: "receive",
   caption: "Receive",
+  link: urls.RECEIVE_TAB,
   component: TabReceive
 }
 
-export default TransactionsTab
+export default ReceiveTab

--- a/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
@@ -5,6 +5,8 @@ import Wrapper from "app/renderer/ui/components/wrapper"
 import { InputDefault } from "app/renderer/ui/components/input"
 import { ActionButton } from "app/renderer/ui/components/button"
 
+import * as urls from "app/renderer/constants/urls"
+
 const styles = require("./style.scss")
 
 /**
@@ -42,10 +44,11 @@ class TabSend extends TabComponent<any> {
   }
 }
 
-const TransactionsTab: TabInfo = {
+const SendTab: TabInfo = {
   key: "send",
   caption: "Send",
+  link: urls.SEND_TAB,
   component: TabSend
 }
 
-export default TransactionsTab
+export default SendTab

--- a/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/send/index.tsx
@@ -47,7 +47,7 @@ class TabSend extends TabComponent<any> {
 const SendTab: TabInfo = {
   key: "send",
   caption: "Send",
-  link: urls.SEND_TAB,
+  path: urls.SEND_TAB,
   component: TabSend
 }
 

--- a/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
@@ -80,7 +80,7 @@ class Transactions extends TabComponent<any> {
 const TransactionsTab: TabInfo = {
   key: "transactions",
   caption: "Transactions",
-  link: urls.TRANSACTIONS_TAB,
+  path: urls.TRANSACTIONS_TAB,
   component: Transactions
 }
 

--- a/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
@@ -8,6 +8,8 @@ import Balances from "./balances"
 import Wrapper from "app/renderer/ui/components/wrapper"
 import List from "app/renderer/ui/components/list"
 
+import * as urls from "app/renderer/constants/urls"
+
 import { TabInfo, TabComponent } from "app/renderer/ui/components/main/sections"
 
 import {
@@ -78,6 +80,7 @@ class Transactions extends TabComponent<any> {
 const TransactionsTab: TabInfo = {
   key: "transactions",
   caption: "Transactions",
+  link: urls.TRANSACTIONS_TAB,
   component: Transactions
 }
 

--- a/app/renderer/ui/components/sidebar/sidebarLink.tsx
+++ b/app/renderer/ui/components/sidebar/sidebarLink.tsx
@@ -14,9 +14,7 @@ const styles = require("./style.scss")
  * @interface SideBarLinkProps
  * @extends {SectionInfo}
  */
-export interface SideBarLinkProps extends SectionInfo {
-  link: string
-}
+export type SideBarLinkProps = SectionInfo
 
 /**
  * SideBarLink class used to list links in sidebar component
@@ -35,7 +33,7 @@ export class SideBarLink extends React.Component<SideBarLinkProps & PathNameProp
    * @memberof SideBarLink
    */
   private get active() {
-    return this.props.pathName.indexOf(this.props.link) === 0 && styles.active
+    return this.props.pathName.indexOf(this.props.path) === 0 && styles.active
   }
 
   /**
@@ -52,7 +50,7 @@ export class SideBarLink extends React.Component<SideBarLinkProps & PathNameProp
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
     return (
-      <Link className={join([styles.link, this.active])} to={this.props.link} replace={true}>
+      <Link className={join([styles.link, this.active])} to={this.props.path} replace={true}>
         <i className={join(["fa", this.icon])} />
         <span className={styles["option-icon"]}>{this.props.caption}</span>
       </Link>

--- a/app/renderer/ui/components/topBar/topBarLink.tsx
+++ b/app/renderer/ui/components/topBar/topBarLink.tsx
@@ -21,13 +21,13 @@ export class TopBarLink extends React.Component<TopBarLinkProps & PathNameProp> 
    * @memberof TopBarLink
    */
   private get active() {
-    return this.props.pathName.indexOf(this.props.link) === 0 && styles.active
+    return this.props.pathName.indexOf(this.props.path) === 0 && styles.active
   }
 
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
     return (
-      <Link className={join([styles["link-box"], this.active])} to={this.props.link} replace={true}>
+      <Link className={join([styles["link-box"], this.active])} to={this.props.path} replace={true}>
         {this.props.caption}
       </Link>
     )

--- a/app/renderer/ui/containers/Main.tsx
+++ b/app/renderer/ui/containers/Main.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { Dispatch } from "redux"
-import { RouteComponentProps, Switch } from "react-router"
+import { RouteComponentProps, Switch, Route } from "react-router"
 import { connect } from "react-redux"
 
 import * as urls from "app/renderer/constants/urls"
@@ -16,6 +16,20 @@ import AttestationsSection from "app/renderer/ui/components/main/sections/attest
 import BlockExplorerSection from "app/renderer/ui/components/main/sections/blockExplorer"
 import CommunitySection from "app/renderer/ui/components/main/sections/community"
 import { PropsRoute } from "app/renderer/utils/propsRoute"
+
+import {
+  TabCoins,
+  TabReceive,
+  TabSend,
+  TabTransactions
+} from "app/renderer/ui/components/main/sections/wallet/tabs"
+
+import {
+  TabMyContracts,
+  TabEasyComposer,
+  TabProEditor,
+  TabMarketplace
+} from "app/renderer/ui/components/main/sections/smartContracts/tabs"
 
 /**
  * Props that match redux store state
@@ -61,9 +75,58 @@ const mapStateToProps = (state: StoreState): StateProps => {
  * @class MainContainer
  * @extends {React.Component<RouteComponentProps<any>, void>}
  */
-
 class MainContainer extends
   React.Component<RouteComponentProps<any> & OwnProps & StateProps & DispatchProps> {
+
+  /**
+   * Method to render routing in Wallet Section
+   */
+  private routingWalletSection = () => {
+    return (
+      <Switch>
+        <PropsRoute
+          path={urls.TRANSACTIONS_TAB}
+          ownProps={this.props}
+          component={TabTransactions.component}
+        />
+        <PropsRoute
+          path={urls.COINS_TAB}
+          ownProps={this.props}
+          component={TabCoins.component}
+        />
+        <PropsRoute
+          path={urls.SEND_TAB}
+          ownProps={this.props}
+          component={TabSend.component}
+        />
+        <PropsRoute
+          path={urls.RECEIVE_TAB}
+          ownProps={this.props}
+          component={TabReceive.component}
+        />
+        <PropsRoute
+          path="/"
+          ownProps={this.props}
+          component={TabTransactions.component}
+        />
+      </Switch>
+    )
+  }
+
+  /**
+   * Method to render routing in Smart Contracts section
+   */
+  private routingSmartContractsSection = () => {
+    return (
+      <Switch>
+        <Route path={urls.MY_CONTRACTS_TAB} component={TabMyContracts.component} />
+        <Route path={urls.EASY_COMPOSER_TAB} component={TabEasyComposer.component} />
+        <Route path={urls.PROEDITOR_TAB} component={TabProEditor.component} />
+        <Route path={urls.MARKETPLACE_TAB} component={TabMarketplace.component} />
+        <Route path="/" component={TabMyContracts.component} />
+      </Switch>
+    )
+  }
 
   /** render */
   // tslint:disable-next-line:prefer-function-over-method
@@ -77,11 +140,13 @@ class MainContainer extends
           <PropsRoute
             path={urls.WALLET_SECTION}
             ownProps={this.props}
+            children={this.routingWalletSection()}
             component={WalletSection.component}
           />
           <PropsRoute
             path={urls.SMART_CONTRACTS_SECTION}
             ownProps={this.props}
+            children={this.routingSmartContractsSection()}
             component={SmartContractsSection.component}
           />
           <PropsRoute
@@ -102,6 +167,7 @@ class MainContainer extends
           <PropsRoute
             path="/"
             ownProps={this.props}
+            children={this.routingWalletSection()}
             component={WalletSection.component}
           />
         </Switch>

--- a/app/renderer/ui/containers/Main.tsx
+++ b/app/renderer/ui/containers/Main.tsx
@@ -1,22 +1,119 @@
 import * as React from "react"
-import { RouteComponentProps } from "react-router"
+import { Dispatch } from "redux"
+import { RouteComponentProps, Switch } from "react-router"
+import { connect } from "react-redux"
+
+import * as urls from "app/renderer/constants/urls"
+import { Services } from "app/renderer/services"
+import { StoreState } from "app/renderer/store"
+import { IAction } from "app/renderer/actions/helpers"
+
+import { MainPage } from "app/renderer/ui/components/main"
+
+import WalletSection from "app/renderer/ui/components/main/sections/wallet"
+import SmartContractsSection from "app/renderer/ui/components/main/sections/smartContracts"
+import AttestationsSection from "app/renderer/ui/components/main/sections/attestations"
+import BlockExplorerSection from "app/renderer/ui/components/main/sections/blockExplorer"
+import CommunitySection from "app/renderer/ui/components/main/sections/community"
+import { PropsRoute } from "app/renderer/utils/propsRoute"
 
 /**
- * Wallet Form UI component
+ * Props that match redux store state
+ */
+export interface StateProps {
+}
+
+/**
+ * Props that match redux actions
+ */
+export interface DispatchProps {
+}
+
+/**
+ * Own props
+ */
+export interface OwnProps {
+  services: Services
+}
+
+/**
+ * Function to map the dispatch of actions to props
+ * @param dispatch
+ */
+const mapDispatchToProps = (dispatch: Dispatch<IAction>): DispatchProps => {
+  return {
+  }
+}
+
+/**
+ * Function to map store state to props
+ * @param state
+ */
+const mapStateToProps = (state: StoreState): StateProps => {
+  return ({
+  })
+}
+
+/**
+ * Main container UI component
  *
  * @export
  * @class MainContainer
  * @extends {React.Component<RouteComponentProps<any>, void>}
  */
 
-export class MainContainer extends React.Component<RouteComponentProps<any>, void> {
+class MainContainer extends
+  React.Component<RouteComponentProps<any> & OwnProps & StateProps & DispatchProps> {
+
   /** render */
   // tslint:disable-next-line:prefer-function-over-method
   public render() {
-    return ""
+    return (
+      <MainPage
+        services={this.props.services}
+        locationPathname={this.props.location.pathname}
+      >
+        <Switch>
+          <PropsRoute
+            path={urls.WALLET_SECTION}
+            ownProps={this.props}
+            component={WalletSection.component}
+          />
+          <PropsRoute
+            path={urls.SMART_CONTRACTS_SECTION}
+            ownProps={this.props}
+            component={SmartContractsSection.component}
+          />
+          <PropsRoute
+            path={urls.ATTESTATIONS_SECTION}
+            ownProps={this.props}
+            component={AttestationsSection.component}
+          />
+          <PropsRoute
+            path={urls.BLOCK_EXPLORER_SECTION}
+            ownProps={this.props}
+            component={BlockExplorerSection.component}
+          />
+          <PropsRoute
+            path={urls.COMMUNITY_SECTION}
+            ownProps={this.props}
+            component={CommunitySection.component}
+          />
+          <PropsRoute
+            path="/"
+            ownProps={this.props}
+            component={WalletSection.component}
+          />
+        </Switch>
+      </MainPage>
+    )
   }
 }
 
-export default (
-  MainContainer as any as React.StatelessComponent<RouteComponentProps<any>>
-)
+/**
+ * Connect react component with redux store
+ */
+export default connect<StateProps, DispatchProps, any, StoreState>(
+  mapStateToProps,
+  mapDispatchToProps
+)(MainContainer)

--- a/app/renderer/ui/containers/WalletForm.tsx
+++ b/app/renderer/ui/containers/WalletForm.tsx
@@ -560,40 +560,38 @@ class WalletFormContainer extends
   /** render */
   public render() {
     return (
-      <>
-        <WalletForm spinner={this.state.spinner}>
-          <Switch>
-            <Route
-              path={WALLET_SEED_TYPE_SELECTION}
-              render={this.renderSeedTypeSelection}
-            />
-            <Route
-              path={WALLET_SEED_BACKUP}
-              render={this.renderSeedBackup}
-            />
-            <Route
-              path={WALLET_SEED_CONFIRMATION}
-              render={this.renderSeedConfirmation}
-            />
-            <Route
-              path={WALLET_ENCRYPTION_PASSWORD}
-              render={this.renderEncryptionPassword}
-            />
-            <Route
-              path={WALLET_IMPORT_MNEMONICS}
-              render={this.renderImportMnemonics}
-            />
-            <Route
-              path={WALLET_IMPORT_XPRV}
-              render={this.renderImportXprv}
-            />
-            <Route
-              path="/"
-              render={this.renderWelcome}
-            />
-          </Switch>
-        </WalletForm>
-      </>
+      <WalletForm spinner={this.state.spinner}>
+        <Switch>
+          <Route
+            path={WALLET_SEED_TYPE_SELECTION}
+            render={this.renderSeedTypeSelection}
+          />
+          <Route
+            path={WALLET_SEED_BACKUP}
+            render={this.renderSeedBackup}
+          />
+          <Route
+            path={WALLET_SEED_CONFIRMATION}
+            render={this.renderSeedConfirmation}
+          />
+          <Route
+            path={WALLET_ENCRYPTION_PASSWORD}
+            render={this.renderEncryptionPassword}
+          />
+          <Route
+            path={WALLET_IMPORT_MNEMONICS}
+            render={this.renderImportMnemonics}
+          />
+          <Route
+            path={WALLET_IMPORT_XPRV}
+            render={this.renderImportXprv}
+          />
+          <Route
+            path="/"
+            render={this.renderWelcome}
+          />
+        </Switch>
+      </WalletForm>
     )
   }
 }

--- a/app/renderer/utils/propsRoute.tsx
+++ b/app/renderer/utils/propsRoute.tsx
@@ -15,15 +15,15 @@ export class PropsRoute extends React.Component<any> {
    * Function to render a component combining RouteComponentProps with RoutesProps
    * as props
    */
-  private withOwnProps = (A: typeof React.Component, routesProps: RoutesProps) =>
-    (props: RouteComponentProps<any>) => <A {...routesProps} {...props} />
+  private withOwnProps = (A: typeof React.Component, routesProps: RoutesProps, children: any) =>
+    (props: RouteComponentProps<any>) => (<A {...routesProps} {...props}>{children}</A>)
 
   /**
    * PropsRoute render function.
    */
   public render() {
-    const { path, ownProps, component } = this.props
+    const { path, ownProps, component, children } = this.props
 
-    return <Route path={path} render={this.withOwnProps(component, ownProps)} />
+    return <Route path={path} render={this.withOwnProps(component, ownProps, children)}/>
   }
 }


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Main container now holds the main routing logic (both the sections routing and the tabs routing). The main container and not the main page component is the one that is being rendered from the routes. Main container is now pre-connected with redux for future use.

Additionally, URLs used under /main have been moved to the URL constants file (re #329). Also, the refactor of the smart contracts section fixes #383.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
