### PR TITLE
feat(api): add generateAddress API renderer function

### DIFF
--- a/app/common/runtimeTypes/ipc/address.ts
+++ b/app/common/runtimeTypes/ipc/address.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts"
 
 import { KeyPath } from "app/common/runtimeTypes/storage/wallets"
+import { GENERIC_IPC_ERROR } from "app/common/runtimeTypes/ipc"
 
 export const GenerateAddressParams = t.intersection([
   t.type({
@@ -12,7 +13,6 @@ export const GenerateAddressParams = t.intersection([
     expirationDate: t.number
   })
 ], "GenerateAddressParams")
-
 export type GenerateAddressParams = t.TypeOf<typeof GenerateAddressParams>
 
 export const GenerateAddressSuccess = t.type({
@@ -24,10 +24,33 @@ export const GenerateAddressSuccess = t.type({
 
 export type GenerateAddressSuccess = t.TypeOf<typeof GenerateAddressSuccess>
 
+export const generateAddressErrors = {
+  GENERIC_IPC_ERROR
+}
+
+export const generateAddressErrorMessages = {
+  GENERIC_IPC_ERROR: "Unknown Error"
+}
+
+export const GenerateAddressErrors = t.union(Object.values(generateAddressErrors))
+export type GenerateAddressErrors = t.TypeOf<typeof GenerateAddressErrors>
+
+export const GenerateAddressError = t.type({
+  kind: t.literal("ERROR"),
+  error: GenerateAddressErrors
+})
+export type GenerateAddressError = t.TypeOf<typeof GenerateAddressError>
+
 export const GenerateAddressResponse = t.taggedUnion(
   "kind",
-  [GenerateAddressSuccess],
+  [GenerateAddressSuccess, GenerateAddressError],
   "GenerateAddressResponse"
 )
-
 export type GenerateAddressResponse = t.TypeOf<typeof GenerateAddressResponse>
+
+/** Factory function for `GenerateAddressError` */
+export function buildGenerateAddressError(error: t.LiteralType<GenerateAddressErrors>) {
+  const addressError: GenerateAddressError = { kind: "ERROR", error: error.value }
+
+  return addressError
+}

--- a/app/renderer/api/generateAddress.ts
+++ b/app/renderer/api/generateAddress.ts
@@ -1,0 +1,51 @@
+import * as t from "io-ts"
+
+import { Contexts, asRuntimeType } from "app/common/runtimeTypes"
+import { ApiClient } from "app/renderer/api"
+import {
+  GenerateAddressResponse,
+  generateAddressErrors,
+  buildGenerateAddressError,
+  GenerateAddressErrors
+} from "app/common/runtimeTypes/ipc/address"
+
+/**
+ * Function to request the generation of an address through the API Client
+ * @param client
+ * @param account
+ * @param label
+ * @param amount
+ * @param expirationDate
+ */
+export async function generateAddress(
+  client: ApiClient,
+  account: number,
+  label?: string,
+  amount?: number,
+  expirationDate?: number
+): Promise<GenerateAddressResponse> {
+  return client.request("generateAddress", { account, label, amount, expirationDate })
+    .then(parseResponse)
+    .catch(buildError)
+}
+
+/**
+ * Function to check that the received response is a valid response
+ * @param response
+ */
+function parseResponse(response: any) {
+  try {
+    return asRuntimeType(response, GenerateAddressResponse, Contexts.IPC)
+  } catch (error) {
+    throw generateAddressErrors.GENERIC_IPC_ERROR
+  }
+}
+
+/**
+ * Function to build a generic IPC error that abstracts from IPC errors
+ */
+function buildError() {
+  return buildGenerateAddressError(
+    t.literal<GenerateAddressErrors>(generateAddressErrors.GENERIC_IPC_ERROR.value)
+  )
+}

--- a/app/renderer/api/index.ts
+++ b/app/renderer/api/index.ts
@@ -20,6 +20,7 @@ export { getWalletInfos } from "./getWalletInfos"
 export { getWallet } from "./getWallet"
 export { encryptWallet } from "./encryptWallet"
 export { validateMnemonics, validateXprv } from "./validateMnemonics"
+export { generateAddress } from "./generateAddress"
 
 /** Options type expected by `Client` */
 export type Options = {

--- a/test/app/renderer/api/generateAddress.spec.ts
+++ b/test/app/renderer/api/generateAddress.spec.ts
@@ -1,0 +1,81 @@
+import { asObject } from "app/common/runtimeTypes"
+import { ipcRendererFactory } from "test/__stubs__/ipcRenderer"
+import { jsonSerializer } from "test/__stubs__/serializers"
+import * as api from "app/renderer/api"
+//import { routes } from "app/main/api"
+import { GenerateAddressParams, GenerateAddressSuccess } from "app/common/runtimeTypes/ipc/address"
+
+describe("GenerateAddress API", () => {
+  // Params
+  const generateAddressParams: GenerateAddressParams = {
+    account: 0,
+    label: "From Satoshi Nakamoto",
+    amount: 1,
+    expirationDate: 1526342400  // May 15, 2018
+  }
+
+  // Response
+  const generateAddressSuccess: GenerateAddressSuccess = {
+    kind: "SUCCESS",
+    keyPath: [2147483651, 2147488567, 2147483648, 0, 0],
+    address: "wit1qre9fq64r5jgv0t3m8q3tvnqwphxm9xpacvrdhe5",
+    creationDate: 1525478400    // May 5, 2018
+  }
+
+  // Mock response
+  const messageHandler = jest.fn()
+  messageHandler.mockResolvedValue(asObject(generateAddressSuccess, GenerateAddressSuccess))
+
+  // Build API client with mocked response
+  const options = {
+    ...api.defaultOptions,
+    timeout: 0,
+    idGen: () => "some generated id",
+    json: jsonSerializer,
+    ipc: ipcRendererFactory(),
+    messageHandler
+  }
+  const client = new api.Client(options)
+
+  it("should return a valid address", async () => {
+    // Call generateAddress renderer function to trigger a
+    // JSON-RPC request and wait for the response
+    const response = await api.generateAddress(
+      client,
+      generateAddressParams.account,
+      generateAddressParams.label,
+      generateAddressParams.amount,
+      generateAddressParams.expirationDate
+    )
+
+    // Check that mocked response was returned correctly
+    expect(response).toMatchObject(generateAddressSuccess)
+  })
+
+  // Check that requested method is routed to a backend handler
+  it("should send a routable JSON-RPC request", async () => {
+    const expected = {
+      jsonrpc: "2.0",
+      id: "some generated id",
+      method: "generateAddress",
+      params: generateAddressParams
+    }
+
+    // Call generateAddress renderer function to trigger a
+    // JSON-RPC request and wait for the response
+    await api.generateAddress(
+      client,
+      generateAddressParams.account,
+      generateAddressParams.label,
+      generateAddressParams.amount,
+      generateAddressParams.expirationDate
+    )
+
+    // Check that the requested method is in the routes of the main process
+    // TODO: uncomment when issue #391 is done (backend handler is implemented)
+    //expect(messageHandler.mock.calls[0][1].method in routes).toBe(true)
+
+    // Check that the message handler function has been called correctly
+    expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
+  })
+})

--- a/test/app/renderer/api/getWallet.spec.ts
+++ b/test/app/renderer/api/getWallet.spec.ts
@@ -64,44 +64,4 @@ describe("GetWallet API", () => {
     // Check that the message handler function has been called correctly
     expect(messageHandler).toBeCalledWith(jsonSerializer, expected)
   })
-
-  // it("should be able to do balahablah", async () => {
-
-  //   const walletResponseFixture: GetWalletResponse = {
-  //     kind: "SUCCESS",
-  //     wallet: {
-  //       _v: CURRENT_WALLET_VERSION,
-  //       id: "test",
-  //       caption: "test wallet",
-  //       seed: {
-  //         mnemonics: "",
-  //         kind: "Wip3",
-  //         seed: { masterSecret: Buffer.from(""), chainCode: Buffer.from("") }
-  //       },
-  //       epochs: { last: 0 },
-  //       purpose: 0x80000003,
-  //       accounts: []
-  //     }
-  //   }
-
-  //   const walletResponse = asObject(walletResponseFixture, GetWalletResponse)
-  //   expect(asRuntimeType(walletResponse, GetWalletResponse)).toMatchObject(walletResponseFixture)
-
-  //   const messageHandler = jest.fn()
-  //   messageHandler.mockResolvedValue(walletResponseFixture)
-  //   const options = {
-  //     ...api.defaultOptions,
-  //     timeout: 0,
-  //     idGen: () => "some generated id",
-  //     json: jsonSerializer,
-  //     ipc: ipcRendererFactory(),
-  //     messageHandler
-  //   }
-  //   const client = new api.Client(options)
-  //   const response = await api.getWallet(client, getWalletParams.id, getWalletParams.password)
-  //   // console.log(response)
-  //   expect(response).toMatchObject(walletResponseFixture)
-
-  // })
-
 })


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

It adds the API renderer function to request the generation of an address from the front-end side to the back-end corresponding handler. Tests are added for this function.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
