### PR TITLE
fix(handler): fix bug when handling errors in getWallet handler

### DIFF
--- a/app/common/runtimeTypes/ipc/wallets.ts
+++ b/app/common/runtimeTypes/ipc/wallets.ts
@@ -66,7 +66,7 @@ export const getWalletErrors = {
   INVALID_PARAMS_TYPE: t.literal("INVALID_PARAMS_TYPE"),
   INVALID_WALLET_TYPE: t.literal("INVALID_WALLET_TYPE"),
   CANNOT_ENCODE_WALLET: t.literal("CANNOT_ENCODE_WALLET"),
-  INVALID_PASSWORD: t.literal("INVALID_PASSWORD"),
+  WRONG_PASSWORD: t.literal("WRONG_PASSWORD"),
   WALLET_NOT_FOUND: t.literal("WALLET_NOT_FOUND"),
   INSUFFICIENT_PERMISSIONS: t.literal("INSUFFICIENT_PERMISSIONS"),
   GENERIC_IPC_ERROR
@@ -76,7 +76,7 @@ export const getWalletErrorMessages = {
   INVALID_PARAMS_TYPE: "Invalid Params Type",
   INVALID_WALLET_TYPE: "Invalid Wallet Type",
   CANNOT_ENCODE_WALLET: "Cannot Encode Wallet",
-  INVALID_PASSWORD: "Invalid Password",
+  WRONG_PASSWORD: "Wrong Password",
   WALLET_NOT_FOUND: "Wallet Not Found",
   INSUFFICIENT_PERMISSIONS: "Insufficient Permissions",
   GENERIC_IPC_ERROR: "Unknown Error"

--- a/app/main/api/handlers/getWallet.ts
+++ b/app/main/api/handlers/getWallet.ts
@@ -30,6 +30,8 @@ export default async function getWallet(
     .then(inject(replaceStorage, system))
     // search wallet in db
     .then(searchWallet)
+    // validate wallet type
+    .then(parseWallet)
     // create response steps
     .then(buildSuccess)
     .catch(buildGetWalletError)
@@ -103,22 +105,29 @@ async function replaceStorage(params: GetWalletParams, system: SubSystems)
 /**
  * search wallet in db
  *
- * @param {{ storage: Storage<Buffer, JsonSerializable, Buffer, Buffer>, id: string }}
- * @returns {Promise<Wallet>}
+ * @param {{ storage: JsonAesLevelStorage, id: string }}
+ * @returns {Promise<JsonSerializable>}
  */
 async function searchWallet(
   { storage, id }: { storage: JsonAesLevelStorage, id: string }
-): Promise<Wallet> {
+): Promise<JsonSerializable> {
   try {
-    const data = await storage.get("wallet")
-
-    try {
-      return asRuntimeType(data, Wallet)
-    } catch (error) {
-      throw getWalletErrors.INVALID_WALLET_TYPE
-    }
+    return await storage.get("wallet")
   } catch (error) {
-    throw getWalletErrors.INVALID_PASSWORD
+    throw getWalletErrors.WRONG_PASSWORD
+  }
+}
+
+/**
+ * parse the wallet retrieved from the db
+ * @param {data: JsonSerializable}
+ * @returns {Promise<Wallet>}
+ */
+async function parseWallet(data: JsonSerializable): Promise<Wallet> {
+  try {
+    return asRuntimeType(data, Wallet)
+  } catch (error) {
+    throw getWalletErrors.INVALID_WALLET_TYPE
   }
 }
 


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

At the promise chain of the `getWallet` handler, we now have different functions for retrieving the wallet from the database and for validating the type of the retrieved wallet. Fixes #433. 


[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
