### PR TITLE
feat(dropdowns): put final copies for options in dropdowns

### DIFF
--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -203,17 +203,24 @@ class TabReceive extends TabComponent<any & Props> {
   public render() {
     const loading = `${styles.loading} ${this.state.loading ? styles.active : ""}`
 
-    const confirmedOptions = ["Option 1", "Option 2", "Option 3"].map((opt: string) => (
-      {
-        text: opt,
-        onClick: () => this.props.services.showUnimplementedMessage()
-      }
-    ))
+    const listOptions = ["Export all payment requests as CSV"].map((opt: string) => ({
+      text: opt,
+      onClick: () => this.props.services.showUnimplementedMessage()
+    }))
+
+    const itemOptions = [
+      "Copy address",
+      "Generate QR code",
+      "View related transactions in block explorer"
+    ].map((opt: string) => ({
+      text: opt,
+      onClick: () => this.props.services.showUnimplementedMessage()
+    }))
 
     const paymentRequestsList = (
       <List
         classNameList={styles.list}
-        dataSource={this.mapAccountToPaymentRequests(confirmedOptions)}
+        dataSource={this.mapAccountToPaymentRequests(itemOptions)}
         renderItem={PaymentRequest}
         emptyIcon="generic"
         emptyText="You don't have payment requests"
@@ -283,7 +290,7 @@ class TabReceive extends TabComponent<any & Props> {
 
           <Wrapper
             title="MY PAYMENT REQUESTS"
-            actions={confirmedOptions}
+            actions={listOptions}
             empty={noPaymentRequests}
           >
             {paymentRequestsList}

--- a/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/transactions/index.tsx
@@ -38,16 +38,13 @@ interface OwnProps {
 class Transactions extends TabComponent<TabProps & PathNameProp & OwnProps> {
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
-    const confirmedOptions = ["Option 1", "Option 2", "Option 3"].map((opt: string) => (
-    {
+    const listOptions = ["Export all transactions as CSV", "View in block explorer"]
+      .map((opt: string) => ({
         text: opt,
         onClick: () => {
           this.props.services.showUnimplementedMessage()
-
-          return
         }
-      }
-    ))
+      }))
 
     const pendingTransactionsList = (
       <List
@@ -81,7 +78,7 @@ class Transactions extends TabComponent<TabProps & PathNameProp & OwnProps> {
           <Wrapper
             title="CONFIRMED"
             caption={`${this.props.confirmedTransactions.length} transactions`}
-            actions={confirmedOptions}
+            actions={listOptions}
             className={styles.confirmed}
             empty={!this.props.confirmedTransactions.length}
           >
@@ -93,7 +90,7 @@ class Transactions extends TabComponent<TabProps & PathNameProp & OwnProps> {
           <Balances className={styles.balances} {...balanceData} />
           <Wrapper
             title="VESTING SCHEDULE GRAPH"
-            actions={confirmedOptions}
+            actions={listOptions}
             className={styles["vesting-graph"]}
             empty={true}
 


### PR DESCRIPTION
This commit replaces placeholders in dropdowns with the actual final copies in the sections that are already implemented.

Future sections will need to implement their own copies, which I set forth in the comments of issue #445.

No tests as this has no impact to business logic.

close #445

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**


[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
