### PR TITLE
fix(ui): select first tab when navigating to a section

### DIFF
--- a/app/renderer/ui/components/main/sections/community/index.tsx
+++ b/app/renderer/ui/components/main/sections/community/index.tsx
@@ -25,6 +25,7 @@ export class Community extends React.Component<SectionProps> {
 const CommunitySection: SectionInfo = {
   key: "community",
   caption: "Community",
+  sectionPath: urls.COMMUNITY_SECTION,
   path: urls.COMMUNITY_SECTION,
   component: Community,
   icon: "users"

--- a/app/renderer/ui/components/main/sections/dataRequests/index.tsx
+++ b/app/renderer/ui/components/main/sections/dataRequests/index.tsx
@@ -25,6 +25,7 @@ class DataRequests extends React.Component<SectionProps> {
 const DataRequestsSection: SectionInfo = {
   key: "datarequests",
   caption: "Data Requests",
+  sectionPath: urls.DATA_REQUESTS_SECTION,
   path: urls.DATA_REQUESTS_SECTION,
   component: DataRequests,
   icon: "eye"

--- a/app/renderer/ui/components/main/sections/index.tsx
+++ b/app/renderer/ui/components/main/sections/index.tsx
@@ -52,6 +52,7 @@ export class SectionComponent<Props> extends React.Component<SectionProps & Prop
 export interface SectionInfo {
   key: string
   caption: string
+  sectionPath: string
   path: string
   icon?: string
   component: React.ComponentClass<SectionProps>

--- a/app/renderer/ui/components/main/sections/marketplace/index.tsx
+++ b/app/renderer/ui/components/main/sections/marketplace/index.tsx
@@ -44,6 +44,7 @@ class Marketplace extends React.Component<SectionProps> {
 const MarketplaceSection: SectionInfo = {
   key: "marketplace",
   caption: "Marketplace",
+  sectionPath: urls.MARKETPLACE_SECTION,
   path: urls.MARKETPLACE_SECTION,
   component: Marketplace,
   icon: "shopping-bag"

--- a/app/renderer/ui/components/main/sections/smartContracts/index.tsx
+++ b/app/renderer/ui/components/main/sections/smartContracts/index.tsx
@@ -47,7 +47,8 @@ class SmartContracts extends React.Component<SectionProps> {
 const SmartContractsSection: SectionInfo = {
   key: "smartcontracts",
   caption: "Smart Contracts",
-  path: urls.SMART_CONTRACTS_SECTION,
+  sectionPath: urls.SMART_CONTRACTS_SECTION,
+  path: urls.MY_CONTRACTS_TAB,
   component: SmartContracts,
   icon: "code"
 }

--- a/app/renderer/ui/components/main/sections/wallet/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/index.tsx
@@ -75,7 +75,8 @@ class Wallet extends React.Component<SectionProps> {
 const WalletSection: SectionInfo = {
   key: "wallet",
   caption: "Wallet",
-  path: urls.WALLET_SECTION,
+  sectionPath: urls.WALLET_SECTION,
+  path: urls.TRANSACTIONS_TAB,
   icon: "book",
   component: Wallet
 }

--- a/app/renderer/ui/components/sidebar/sidebarLink.tsx
+++ b/app/renderer/ui/components/sidebar/sidebarLink.tsx
@@ -33,7 +33,7 @@ export class SideBarLink extends React.Component<SideBarLinkProps & PathNameProp
    * @memberof SideBarLink
    */
   private get active() {
-    return this.props.pathName.indexOf(this.props.path) === 0 && styles.active
+    return this.props.pathName.indexOf(this.props.sectionPath) === 0 && styles.active
   }
 
   /**


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to Sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

The URL of the first tab needs to be indicated as the main URL of the section in the `SectionInfo`. This needs to be done for all routed sections after this PR as well.

fix #455

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
