### PR TITLE
fix(address): fix logic where addresses and prefilled data were combined

### DIFF
--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -184,7 +184,6 @@ class TabReceive extends TabComponent<any & Props> {
       .accounts[this.props.selectedAccount]
       .keyChains[KEYCHAIN_INDICES.KEYCHAIN_EXTERNAL]
       .finalKeys
-      .sort(byCreationDate)
       .map((finalKey: FinalKey, index: number) => {
         return buildComputedPaymentRequest(
           finalKey as ExternalFinalKey,
@@ -197,6 +196,7 @@ class TabReceive extends TabComponent<any & Props> {
           options
         )
       })
+      .reverse()
   }
 
   // tslint:disable-next-line:prefer-function-over-method completed-docs
@@ -314,19 +314,6 @@ class TabReceive extends TabComponent<any & Props> {
         </div>
       </>
     )
-  }
-}
-
-/**
- * Function to sort external final keys by creation date
- * @param a
- * @param b
- */
-const byCreationDate = (a: ExternalFinalKey, b: ExternalFinalKey) => {
-  if (a.metadata && b.metadata && a.metadata.creationDate && b.metadata.creationDate) {
-    return b.metadata.creationDate - a.metadata.creationDate
-  } else {
-    return 0
   }
 }
 


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

Addresses are not sorted anymore by creation date but instead, the array of final keys is reversed
(as new addresses are just pushed at the end of the array).

fix #464

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
