### PR TITLE
fix(ui-compo): remove duplicated div grid layout

### DIFF
--- a/app/renderer/ui/components/main/sections/dataRequests/index.tsx
+++ b/app/renderer/ui/components/main/sections/dataRequests/index.tsx
@@ -9,7 +9,6 @@ import TopBar from "app/renderer/ui/components/topBar"
 import { PropsRoute } from "app/renderer/utils/propsRoute"
 import { TabHistory, TabEditor } from "app/renderer/ui/components/main/sections/dataRequests/tabs"
 
-const styles = require("./style.scss")
 const mainStyles = require("app/renderer/ui/components/main/style.scss")
 
 /**
@@ -39,25 +38,23 @@ class DataRequests extends React.Component<SectionProps> {
           pathName={this.props.pathName}
           linksProps={topBarlinkProps}
         />
-        <div className={styles.layout}>
-          <Switch>
-            <PropsRoute
-              path={urls.DATA_REQUESTS_HISTORY_TAB}
-              ownProps={this.props}
-              component={TabHistory.component}
-            />
-            <PropsRoute
-              path={urls.DATA_REQUESTS_EDITOR_TAB}
-              ownProps={this.props}
-              component={TabEditor.component}
-            />
-            <PropsRoute
-              path="/"
-              ownProps={this.props}
-              component={TabHistory.component}
-            />
-          </Switch>
-        </div>
+        <Switch>
+          <PropsRoute
+            path={urls.DATA_REQUESTS_HISTORY_TAB}
+            ownProps={this.props}
+            component={TabHistory.component}
+          />
+          <PropsRoute
+            path={urls.DATA_REQUESTS_EDITOR_TAB}
+            ownProps={this.props}
+            component={TabEditor.component}
+          />
+          <PropsRoute
+            path="/"
+            ownProps={this.props}
+            component={TabHistory.component}
+          />
+        </Switch>
       </>
     )
   }

--- a/app/renderer/ui/components/main/sections/dataRequests/style.scss
+++ b/app/renderer/ui/components/main/sections/dataRequests/style.scss
@@ -5,4 +5,11 @@
     grid-template-columns: 3fr 1fr;
     padding: 0;
   }
+
+  .paddedLayout {
+    display: grid;
+    grid-gap: 2em;
+    grid-template-columns: 3fr 1fr;
+    padding: 3em;
+  }
 }

--- a/app/renderer/ui/components/main/sections/dataRequests/tabs/editor/index.tsx
+++ b/app/renderer/ui/components/main/sections/dataRequests/tabs/editor/index.tsx
@@ -12,6 +12,7 @@ const svgRetrieval = require("svg/dataRequestsEditorRetrieval.svg")
 const svgAttestation = require("svg/dataRequestsEditorAttestation.svg")
 const svgDelivery = require("svg/dataRequestsEditorDelivery.svg")
 
+const layoutStyles = require("app/renderer/ui/components/main/sections/smartContracts/style.scss")
 const styles = require("./style.scss")
 const tabStyles = require("app/renderer/ui/components/main/sections/smartContracts/tabs/style.scss")
 
@@ -33,7 +34,7 @@ class TabEditor extends TabComponent<any & Props> {
   // tslint:disable-next-line:prefer-function-over-method completed-docs
   public render() {
     return (
-      <div className={styles.layout}>
+      <div className={layoutStyles.layout}>
         <div className={`${styles.bar}`}>
           <img src={svgBar} />
         </div>

--- a/app/renderer/ui/components/main/sections/dataRequests/tabs/editor/style.scss
+++ b/app/renderer/ui/components/main/sections/dataRequests/tabs/editor/style.scss
@@ -48,13 +48,6 @@
     padding-left: 3em;
   }
 
-  .layout {
-    display: grid;
-    grid-gap: 2em;
-    grid-template-columns: 3fr 1fr;
-    padding: 0;
-  }
-
   .param {
     padding: 0 10px 5px 0;
     text-align: right;

--- a/app/renderer/ui/components/main/sections/dataRequests/tabs/history/index.tsx
+++ b/app/renderer/ui/components/main/sections/dataRequests/tabs/history/index.tsx
@@ -7,6 +7,7 @@ import { Services } from "app/renderer/services"
 import { CardDefault } from "app/renderer/ui/components/card"
 
 const svgImage = require("svg/dataRequestsHistory.svg")
+const layoutStyles = require("app/renderer/ui/components/main/sections/smartContracts/style.scss")
 const styles = require("./style.scss")
 
 /**
@@ -40,7 +41,7 @@ class TabHistory extends TabComponent<any & Props> {
     ))
 
     return (
-      <div className={styles.layout}>
+      <div className={layoutStyles.paddedLayout}>
         <div className={styles.left}>
           <Wrapper
             title="BY TEMPLATE"

--- a/app/renderer/ui/components/main/sections/dataRequests/tabs/history/style.scss
+++ b/app/renderer/ui/components/main/sections/dataRequests/tabs/history/style.scss
@@ -28,11 +28,4 @@
   .withPadding div {
     padding: 12px !important;
   }
-
-  .layout {
-    display: grid;
-    grid-gap: 2em;
-    grid-template-columns: 3fr 1fr;
-    padding: 3em;
-  }
 }


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

This PR removes a duplicated grid layout in the data requests section. It also refactors some of the styles so that the smart contracts and data requests sections are using the styles in a similar way.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
