### PR TITLE
feat(ux): add success notification toast when a payment request is generated

### DIFF
--- a/app/renderer/index.tsx
+++ b/app/renderer/index.tsx
@@ -5,8 +5,10 @@ import { message } from "antd"
 import { render } from "react-dom"
 import Root from "app/renderer/ui/containers/Root"
 import "./ui/app.global.scss"
-import { UnimplementedMessage } from "app/renderer/ui/components/unimplementedMessage"
 import { Services } from "app/renderer/services"
+import { UnimplementedMessage } from "app/renderer/ui/components/unimplementedMessage"
+import GenericMessage from "app/renderer/ui/components/genericMessage"
+
 const apiClient = new api.Client()
 
 /**
@@ -18,6 +20,15 @@ function showUnimplementedMessage() {
   return message.info(<UnimplementedMessage />)
 }
 
+/**
+ * Call antd success message to show component configurable by text
+ *
+ * @returns
+ */
+function showSuccess(msg: string) {
+  return message.success(<GenericMessage className="success" msg={msg} />)
+}
+
 // Related to issue 390
 document.location.hash = "#/"
 
@@ -26,7 +37,8 @@ new Promise(async () => {
   // dependency injection.
   const services: Services = {
     apiClient,
-    showUnimplementedMessage
+    showUnimplementedMessage,
+    showSuccess
   }
 
   // Query and parse wallets from main process

--- a/app/renderer/services.ts
+++ b/app/renderer/services.ts
@@ -6,4 +6,7 @@ export type Services = {
 
   // Method to show a message for a not-yet-implemented functionality
   showUnimplementedMessage: () => void
+
+  // Method to show a success message
+  showSuccess: (message: string) => void
 }

--- a/app/renderer/ui/app.global.scss
+++ b/app/renderer/ui/app.global.scss
@@ -120,13 +120,38 @@
     }
 
     .ant-message-notice-content {
-      background: $toast-background;
-      border-radius: 8% / 50%;
-      opacity: 0.8;
-      padding: 25px 50px 25px 50px;
+      background: transparent;
+      border-radius: 0;
+      -webkit-box-shadow: 0 0;
+      box-shadow: 0 0;
+      display: inline-block;
+      padding: 0;
+      pointer-events: all;
+    }
+
+    .ant-message-info {
+      background: $toast-info-background;
+      border-radius: 41px / 37px;
+      -webkit-box-shadow: $toast-box-shadow;
+      box-shadow: $toast-box-shadow;
+      opacity: $toast-opacity;
+      padding: $toast-padding;
 
       .anticon {
-        display: none;
+        display: $toast-display-anticon;
+      }
+    }
+
+    .ant-message-success {
+      background: $toast-success-background;
+      border-radius: 41px / 37px;
+      -webkit-box-shadow: $toast-box-shadow;
+      box-shadow: $toast-box-shadow;
+      opacity: $toast-opacity;
+      padding: $toast-padding;
+
+      .anticon {
+        display: $toast-display-anticon;
       }
     }
 

--- a/app/renderer/ui/components/genericMessage/index.tsx
+++ b/app/renderer/ui/components/genericMessage/index.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+
+const styles = require("./style.scss")
+
+export interface OwnProps {
+  className: string
+  msg: string
+}
+
+/**
+ * Component that renders a message passed as props
+ */
+export default class GenericMessage extends React.Component<OwnProps> {
+  // tslint:disable-next-line: completed-docs
+  public render() {
+    return (
+      <p className={styles[this.props.className]}>
+        {this.props.msg}
+      </p>
+    )
+  }
+}

--- a/app/renderer/ui/components/genericMessage/style.scss
+++ b/app/renderer/ui/components/genericMessage/style.scss
@@ -1,0 +1,8 @@
+:local {
+  @import "app/renderer/ui/theme";
+  @import "app/renderer/ui/fonts";
+
+  .success {
+    color: $toast-color;
+  }
+}

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -166,6 +166,9 @@ class TabReceive extends TabComponent<any & Props> {
           expires: "",
           loading: false
         })
+
+        // Show success message
+        this.props.services.showSuccess("You have successfully created a payment request")
       })
       .catch((error) => {
         // Reset loading state and show error

--- a/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
+++ b/app/renderer/ui/components/main/sections/wallet/tabs/receive/index.tsx
@@ -36,6 +36,7 @@ import {
 
 import { encodeBech32 } from "app/common/witnet-js/addresses/p2pkh"
 import { ChainType } from "app/common/chain/chainType"
+import { sleep } from "app/renderer/utils/sleep"
 
 const styles = require("./style.scss")
 
@@ -145,6 +146,9 @@ class TabReceive extends TabComponent<any & Props> {
 
     // Set loading state
     this.setState({ loading: true, errorMessage: "" })
+
+    // Add an insignificant delay (1s) to improve user experience
+    await sleep(1000)
 
     // Generate Address for selected account (array index)
     this.generateAddress(this.state.label, this.state.amount, this.state.expires)

--- a/app/renderer/ui/theme.scss
+++ b/app/renderer/ui/theme.scss
@@ -227,10 +227,15 @@ $tab_send-info-font_size: 12px;
 $tab_send-info-font_weight: 200;
 
 // TOAST
-$toast-background: $grey-7;
+$toast-info-background: $grey-7;
+$toast-success-background: $green-7;
 $toast-color: $grey-1;
 $toast-font_size: 14px;
 $toast-font_weight: 800;
+$toast-opacity: 0.8;
+$toast-padding: 25px 50px 25px 50px;
+$toast-box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+$toast-display-anticon: none;
 
 // TOOLTIP
 $tooltip_title-color: $font-color-dark;

--- a/app/renderer/utils/sleep.ts
+++ b/app/renderer/utils/sleep.ts
@@ -1,0 +1,8 @@
+/**
+ * Function that returns a promise that is resolved after
+ * the specified delay (in ms)
+ * @param ms
+ */
+export async function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [x] I have read and understood [CODE_OF_CONDUCT][code] document.
- [x] I have read and understood [CONTRIBUTING][cont] document.
- [x] I have read and understood [STYLEGUIDE][style] document.
- [x] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [x] My code is formatted and is accepted by `yarn fmt`.
- [x] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

This PR adds a success notification toast when a payment request is successfully generated. It also adds a one-second delay in order to improve UX.

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
