### PR TITLE
Fix get addresses

### DIFF
--- a/src/components/Transactions.vue
+++ b/src/components/Transactions.vue
@@ -73,13 +73,14 @@ export default {
     return {
       dialogVisible: false,
       dialogVisible2: false,
-      posts: this.addresses,
+      posts: this.newAddresses,
       lastAddress: '',
       page: 1,
       perPage: 5,
       middleItemActive: null,
       lastItemActive: false,
       firstItemActive: true,
+      newAddresses: null,
     }
   },
   computed: {
@@ -99,9 +100,7 @@ export default {
       getTransactionsError: state => {
         return state.wallet.errors.getTransactions
       },
-      addresses: state => {
-        return state.wallet.addresses
-      },
+      addresses: state => Array.from(state.wallet.addresses),
       createVTTErrorMessage: state => {
         if (state.wallet.errors.createVTT) {
           return state.wallet.errors.createVTT.message
@@ -139,6 +138,7 @@ export default {
     },
     displayModalReceive: function() {
       this.generateAddress()
+      this.$store.dispatch('getAddresses')
       this.dialogVisible2 = true
     },
     closeAndClear: function() {

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -76,19 +76,16 @@ export default {
     setGeneratedTransaction(state, { transaction }) {
       state.generatedTransaction = transaction
     },
-    setAddresses(state, { addresses, address }) {
-      const addressesMap = new Map([])
-      const addAddress = addr => addressesMap.set(addr.address, addr)
-      state.addresses.map(addAddress)
-
-      if (addresses) {
-        addresses.map(addAddress)
-      }
-
+    addAddress(state, { address }) {
       if (address) {
-        addAddress(address)
+        state.addresses.add(address)
       }
-      state.addresses = Array.from(addressesMap.values())
+    },
+    setAddresses(state, { addresses }) {
+      if (addresses) {
+        state.addresses = addresses
+        state.addresses = new Set(addresses)
+      }
     },
   },
   actions: {
@@ -160,8 +157,8 @@ export default {
       const request = await this.$walletApi.getAddresses({
         walletId: context.state.walletId,
         sessionId: context.state.sessionId,
+        limit: 300,
       })
-
       if (request.result) {
         context.commit('setAddresses', { addresses: request.result.addresses })
       }
@@ -174,7 +171,7 @@ export default {
         sessionId: context.state.sessionId,
       })
       if (request.result) {
-        context.commit('setAddresses', { address: request.result.address })
+        context.commit('addAddress', { address: request.result })
       }
     },
 


### PR DESCRIPTION
The method for setting the list of addresses when generating a new one has been divided into two different methods. The offset of addresses that can be listed is 25, there is a need for checking the argument `offset` to retrieve more than 25 addresses from the Wallet. 