### PR TITLE
Add submit on pressing enter

### DIFF
--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -53,7 +53,6 @@ export default {
 }
 
 :active,
-:focus,
 :hover {
   outline: none;
 }

--- a/src/components/Send.vue
+++ b/src/components/Send.vue
@@ -94,7 +94,14 @@
         <Select v-model="fee" :options="options" />
       </div>
       <div class="submit">
-        <Button data-test="sign-send-btn" :onClick="createVTT" type="primary">Sign and send</Button>
+        <Button
+          @keydown.enter.esc.prevent="createVTT"
+          data-test="sign-send-btn"
+          :onClick="createVTT"
+          type="primary"
+        >
+          Sign and send
+        </Button>
       </div>
     </div>
   </div>
@@ -127,6 +134,7 @@ export default {
         { value: 59, primaryText: 'Medium', secondaryText: '59 uWit/B' },
         { value: 39, primaryText: 'Low', secondaryText: '39 uWit/B' },
       ],
+      refindex: 0,
     }
   },
   computed: {
@@ -144,6 +152,7 @@ export default {
       this.closeDialog()
     },
     createVTT() {
+      this.refindex = 0
       this.$store.dispatch('createVTT', {
         label: this.label,
         address: this.address,

--- a/src/components/WelcomeBack/UnlockWallet.vue
+++ b/src/components/WelcomeBack/UnlockWallet.vue
@@ -6,10 +6,14 @@
       class="password-input"
       v-model="password"
       type="password"
+      id="submit-button"
+      @keydown.enter.esc.prevent="goNextItem"
       placeholder="Password"
     />
-    <div class="submit">
-      <Button data-test="unlock-wallet" :onClick="unlockWallet" type="primary">Unlock</Button>
+    <div @keydown.enter.esc.prevent="unlockWallet">
+      <Button ref="submit" data-test="unlock-wallet" :onClick="unlockWallet" type="primary">
+        Unlock
+      </Button>
     </div>
     <p v-if="showError">Invalid password</p>
   </div>
@@ -29,6 +33,9 @@ export default {
     }
   },
   methods: {
+    goNextItem() {
+      this.$refs.submit.$el.focus()
+    },
     unlockWallet() {
       this.$store.dispatch('unlockWallet', {
         walletId: this.$route.params.id,


### PR DESCRIPTION
This PR adds a submit on pressing the enter key in the send component and in the unlock wallet component. This entails better keyboard accessibility.