### PR TITLE
chore: retry curl if github is down

### DIFF
--- a/ci/initializeWallet.sh
+++ b/ci/initializeWallet.sh
@@ -2,7 +2,17 @@
 
 echo 'Downloading latest witnet node release...'
 
-wget $(curl -s https://api.github.com/repos/witnet/witnet-rust/releases/latest | grep 'browser_' | cut -d\" -f4)
+# Retry curl until success
+while URL=$(curl -s https://api.github.com/repos/witnet/witnet-rust/releases/latest | grep 'browser_' | cut -d\" -f4); [ "$URL" = "" ]; do
+    echo 'Github is down, retrying in 10s'
+    sleep 10s
+done
+
+# Retry wget until success
+# https://stackoverflow.com/a/30986740
+while true; do
+    wget -T 15 -c $URL && break
+done
 
 tar -zxvf witnet-*-x86_64-unknown-linux-gnu.tar.gz
 


### PR DESCRIPTION
This will keep trying to download the witnet release until it works.