### PR TITLE
chore: upgrade radon library

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "vue": "^2.6.11",
     "vue-router": "^3.0.3",
     "vuex": "^3.0.1",
-    "witnet-radon-js": "0.3.7"
+    "witnet-radon-js": "0.3.8"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^4.2.2",


### PR DESCRIPTION
Upgrade radon lib to 0.3.8 which includes operator names in camelCase