### PR TITLE
feat: remove electron toolbar in production environment

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -54,6 +54,11 @@ function createWindow() {
     },
   })
 
+  if (!isDevelopment) {
+    // Hide electron toolbar in production environment
+    win.setMenuBarVisibility(false)
+  }
+
   loadUrl(status)
 
   win.on('closed', () => {


### PR DESCRIPTION
Remove electron toolbar when environment is set to production.

![image](https://user-images.githubusercontent.com/24905681/76431657-30aa0a00-63b2-11ea-9799-fb9a8256e5f3.png)
