### PR TITLE
Generated addresses state

### DIFF
--- a/src/components/claiming/DownloadFile.vue
+++ b/src/components/claiming/DownloadFile.vue
@@ -48,6 +48,9 @@ export default {
       claimingFileInfo: state => {
         return state.wallet.claimingFileInfo
       },
+      claimingProcessCompleted: state => {
+        return state.wallet.claimingProcessState
+      },
       checkTokenGenerationEventDate: state => {
         return state.wallet.checkTokenGenerationEventDate
       },
@@ -66,6 +69,7 @@ export default {
     },
   },
   beforeCreate() {
+    this.$store.dispatch('saveCompletedProcess')
     this.$store.dispatch('getClaimingInfo')
   },
 }

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -32,6 +32,7 @@ export default {
     },
     checkTokenGenerationEventDate: new Date(2020, 4, 16, 17, 23, 42, 0),
     claimingFileInfo: null,
+    claimingProcessState: null,
     mainnetReady: false,
     currency: WIT_UNIT.NANO,
     balances: null,
@@ -115,6 +116,9 @@ export default {
     },
     setClaimingInfo(state, { info }) {
       Object.assign(state, { claimingFileInfo: info })
+    },
+    setClaimingState(state, { completed }) {
+      Object.assign(state, { claimingProcessState: completed })
     },
     setWallet(state, { walletId, sessionId }) {
       state.walletId = walletId
@@ -250,6 +254,9 @@ export default {
         })
       }
     },
+    getClaimingProcessState: function(context) {
+      context.commit('setClaimingState', { completed: localStorage.getItem('completed') })
+    },
     getClaimingInfo: async function(context) {
       const request = await context.state.api.getItem({
         wallet_id: context.rootState.wallet.walletId,
@@ -306,6 +313,10 @@ export default {
           message: 'An error occurred saving the claiming information',
         })
       }
+    },
+    saveCompletedProcess: async function(context) {
+      localStorage.setItem('completed', true)
+      context.dispatch('getClaimingProcessState')
     },
     saveLabel: async function(context, { label, transaction }) {
       const transactionId = transaction.transactionId


### PR DESCRIPTION
This PR saves the claiming process state in local storage to be able to know if the user has generated the addresses correctly.