### PR TITLE
Fix notifications when socket not ready

### DIFF
--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -123,7 +123,11 @@ export default {
           message,
         }
       } else {
-        if (state.networkStatus !== 'error') {
+        const socketNotReady = error === 'socket not ready'
+        const networkStatusError = state.networkStatus === 'error'
+        if (networkStatusError || socketNotReady) {
+          return ''
+        } else {
           // notification options
           const notificationProps = {
             title: error,


### PR DESCRIPTION
Notifications are not shown anymore if the socket is not ready or if there is a connection problem. It redirects instead to the warning view.