### PR TITLE
Fix standardizeWitUnits function

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -38,7 +38,11 @@ export function standardizeWitUnits(amount, unit) {
     [`${WIT_UNIT.MICRO}`]: 3,
     [`${WIT_UNIT.NANO}`]: 0,
   }
-  return (amount / Math.pow(10, units[unit])).toFixed(units[unit]).replace(/\.?0+$/, '')
+  if (unit === WIT_UNIT.NANO) {
+    return amount.toString()
+  } else {
+    return (amount / Math.pow(10, units[unit])).toFixed(units[unit]).replace(/\.?0+$/, '')
+  }
 }
 
 export function encodeDataRequest(radRequest) {

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -58,8 +58,8 @@ describe('standardizeWitUnits', () => {
       })
     })
     it('nanoWit', () => {
-      const expected = '4'
-      const result = standardizeWitUnits(4, WIT_UNIT.NANO)
+      const expected = '40'
+      const result = standardizeWitUnits(40, WIT_UNIT.NANO)
       expect(result).toBe(expected)
     })
   })


### PR DESCRIPTION
This PR fixes the ```standardizeWitUnit``` function to not remove zero digits if the unit provided is nanoWit.