### PR TITLE
Delete the back button in WelcomeForm view when there is no wallet created.

### DIFF
--- a/src/components/steps/WalletSeedTypeSelection.vue
+++ b/src/components/steps/WalletSeedTypeSelection.vue
@@ -24,7 +24,7 @@
           Import a wallet from mnemonics
         </el-button>
       </li>
-      <li class="option">
+      <li v-if="walletInfos.length" class="option">
         <el-button
           class="big"
           data-test="back"
@@ -39,11 +39,17 @@
 
 <script>
 import Card from '@/components/card/Card'
+import { mapState } from 'vuex'
 
 export default {
   name: 'WalletSeedTypeSelection',
   components: {
     Card,
+  },
+  computed: {
+    ...mapState({
+      walletInfos: state => state.wallet.walletInfos,
+    }),
   },
   methods: {
     redirectTo(path) {


### PR DESCRIPTION
It deletes the back button in ```WelcomeForm``` view when there is no wallet created.

<img width="1440" alt="Captura de pantalla 2020-07-06 a las 11 55 37" src="https://user-images.githubusercontent.com/16032491/86580897-a0568d00-bf7f-11ea-9699-ce187660243a.png">
