### PR TITLE
Auto try data request with switch

### DIFF
--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -19,7 +19,7 @@
 
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { EDITOR_STAGES } from '@/constants'
+import { EDITOR_STAGES, EDITOR_TRY_INTERVAL } from '@/constants'
 import { SET_CURRENT_STAGE } from '@/store/mutation-types'
 import EditorToolBar from '@/components/EditorToolBar'
 import EditorStageAggregations from '@/components/EditorStageAggregations'
@@ -47,6 +47,13 @@ export default {
       EDITOR_STAGES,
       logs: [],
       showDeployDR: false,
+      tryInterval: setInterval(() => {
+        console.log('outside')
+        if (this.autoTry && this.dataRequestChanged) {
+          console.log('inside')
+          this.tryDataRequest()
+        }
+      }, EDITOR_TRY_INTERVAL),
     }
   },
   computed: {
@@ -55,7 +62,12 @@ export default {
       networkStatus: state => state.wallet.networkStatus,
       currentStage: state => state.rad.currentStage,
       currentTemplate: state => state.rad.currentTemplate,
+      autoTry: state => state.rad.autoTry,
+      dataRequestChanged: state => state.rad.dataRequestChanged,
     }),
+  },
+  beforeDestroy() {
+    this.tryInterval = null
   },
   created() {
     this.saveTemplate()
@@ -66,7 +78,7 @@ export default {
       clearError: 'clearError',
       changeStage: SET_CURRENT_STAGE,
     }),
-    ...mapActions(['saveTemplate']),
+    ...mapActions(['saveTemplate', 'tryDataRequest']),
     closeDeployModal() {
       this.showDeployDR = false
     },

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -19,7 +19,7 @@
 
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { EDITOR_STAGES, EDITOR_TRY_INTERVAL } from '@/constants'
+import { EDITOR_STAGES, EDITOR_TRY_INTERVAL, EDITOR_SAVE_INTERVAL } from '@/constants'
 import { SET_CURRENT_STAGE } from '@/store/mutation-types'
 import EditorToolBar from '@/components/EditorToolBar'
 import EditorStageAggregations from '@/components/EditorStageAggregations'
@@ -47,10 +47,14 @@ export default {
       EDITOR_STAGES,
       logs: [],
       showDeployDR: false,
+      inactivityInterval: null,
+      saveInterval: setInterval(() => {
+        if (this.dataRequestChangedSinceSaved) {
+          this.saveTemplate()
+        }
+      }, EDITOR_SAVE_INTERVAL),
       tryInterval: setInterval(() => {
-        console.log('outside')
-        if (this.autoTry && this.dataRequestChanged) {
-          console.log('inside')
+        if (this.autoTry && this.dataRequestChangedSinceTried) {
           this.tryDataRequest()
         }
       }, EDITOR_TRY_INTERVAL),
@@ -63,11 +67,13 @@ export default {
       currentStage: state => state.rad.currentStage,
       currentTemplate: state => state.rad.currentTemplate,
       autoTry: state => state.rad.autoTry,
-      dataRequestChanged: state => state.rad.dataRequestChanged,
+      dataRequestChangedSinceTried: state => state.rad.dataRequestChangedSinceTried,
+      dataRequestChangedSinceSaved: state => state.rad.dataRequestChangedSinceSaved,
     }),
   },
   beforeDestroy() {
-    this.tryInterval = null
+    clearInterval(this.tryInterval)
+    clearInterval(this.saveInterval)
   },
   created() {
     this.saveTemplate()

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -19,7 +19,7 @@
 
 <script>
 import { mapActions, mapMutations, mapState } from 'vuex'
-import { EDITOR_STAGES, EDITOR_TRY_INTERVAL, EDITOR_SAVE_INTERVAL } from '@/constants'
+import { EDITOR_STAGES, EDITOR_SAVE_INTERVAL } from '@/constants'
 import { SET_CURRENT_STAGE } from '@/store/mutation-types'
 import EditorToolBar from '@/components/EditorToolBar'
 import EditorStageAggregations from '@/components/EditorStageAggregations'
@@ -53,11 +53,6 @@ export default {
           this.saveTemplate()
         }
       }, EDITOR_SAVE_INTERVAL),
-      tryInterval: setInterval(() => {
-        if (this.autoTry && this.dataRequestChangedSinceTried) {
-          this.tryDataRequest()
-        }
-      }, EDITOR_TRY_INTERVAL),
     }
   },
   computed: {
@@ -67,9 +62,16 @@ export default {
       currentStage: state => state.rad.currentStage,
       currentTemplate: state => state.rad.currentTemplate,
       autoTry: state => state.rad.autoTry,
-      dataRequestChangedSinceTried: state => state.rad.dataRequestChangedSinceTried,
-      dataRequestChangedSinceSaved: state => state.rad.dataRequestChangedSinceSaved,
+      dataRequestChangedSinceSaved: state =>
+        state.rad.dataRequestChangedSinceSaved,
     }),
+  },
+  watch: {
+    dataRequestChangedSinceSaved(newValue) {
+      if (newValue && this.autoTry) {
+        this.tryDataRequest()
+      }
+    },
   },
   beforeDestroy() {
     clearInterval(this.tryInterval)

--- a/src/components/EditorToolBar.vue
+++ b/src/components/EditorToolBar.vue
@@ -45,10 +45,11 @@
           </el-button>
         </el-tooltip>
 
-        <!-- TODO: improve color -->
         <el-switch
           v-else-if="tab.type === 'switch'"
           v-model="autoTryDataRequest"
+          data-test="action-try"
+          active-color="#b47de8"
           class="center"
           active-text="Try data request"
         ></el-switch>
@@ -75,7 +76,7 @@
 <script>
 import { EDITOR_REDO, EDITOR_UNDO, CLEAR_HISTORY } from '@/store/mutation-types'
 import { EDITOR_EXPORT_FORMAT } from '@/constants'
-import { mapState, mapMutations, mapActions } from 'vuex'
+import { mapState, mapMutations } from 'vuex'
 import { deleteKey } from '@/utils'
 
 export default {
@@ -172,6 +173,7 @@ export default {
     }),
     clear() {
       this.clearDataRequestResult()
+      this.toggleTryDataRequest()
       this.clearHistory()
     },
     export(format) {

--- a/src/components/EditorToolBar.vue
+++ b/src/components/EditorToolBar.vue
@@ -45,6 +45,14 @@
           </el-button>
         </el-tooltip>
 
+        <!-- TODO: improve color -->
+        <el-switch
+          v-else-if="tab.type === 'switch'"
+          v-model="autoTryDataRequest"
+          class="center"
+          active-text="Try data request"
+        ></el-switch>
+
         <el-dropdown v-else @command="handleCommand">
           <el-button type="primary" data-test="export-selection">
             {{ tab.text }} <i class="el-icon-arrow-down el-icon--right"></i>
@@ -120,7 +128,7 @@ export default {
           text: 'Try data request',
           action: this.tryDataRequest,
           name: 'try',
-          type: 'button',
+          type: 'switch',
         },
       ],
     }
@@ -129,6 +137,7 @@ export default {
     ...mapState({
       template: state => state.rad.currentTemplate,
       radRequest: state => state.rad.radRequest,
+      autoTry: state => state.rad.autoTry,
     }),
     dataStr() {
       return this.exportFormat === EDITOR_EXPORT_FORMAT.JSON
@@ -144,14 +153,22 @@ export default {
         ? 'template.json'
         : 'data_request.js'
     },
+    autoTryDataRequest: {
+      set() {
+        this.toggleTryDataRequest()
+      },
+      get() {
+        return this.autoTry
+      },
+    },
   },
   methods: {
-    ...mapActions(['tryDataRequest']),
     ...mapMutations({
       undo: EDITOR_UNDO,
       redo: EDITOR_REDO,
       clearHistory: CLEAR_HISTORY,
       clearDataRequestResult: 'clearDataRequestResult',
+      toggleTryDataRequest: 'toggleTryDataRequest',
     }),
     clear() {
       this.clearDataRequestResult()
@@ -243,6 +260,8 @@ export default {
     display: flex;
 
     .btn {
+      align-items: center;
+      display: flex;
       margin-left: 8px;
     }
   }

--- a/src/components/RadonOperator.vue
+++ b/src/components/RadonOperator.vue
@@ -248,7 +248,6 @@ export default {
           id,
           value: '$' + variableMatch.key,
         })
-        this.tryDataRequest()
         this.usedVariables({
           id: id,
           variable: variableMatch.key,
@@ -263,7 +262,6 @@ export default {
           id,
           value: getNativeValueFromMarkupArgumentType(value, type),
         })
-        this.tryDataRequest()
       }
     },
     updateOperatorAndVariables(id, value, type) {

--- a/src/components/RadonOperator.vue
+++ b/src/components/RadonOperator.vue
@@ -214,7 +214,6 @@ export default {
       usedVariables: USED_VARIABLES,
     }),
     ...mapActions({
-      saveTemplate: 'saveTemplate',
       tryDataRequest: 'tryDataRequest',
     }),
     addOperator() {
@@ -266,7 +265,6 @@ export default {
         })
         this.tryDataRequest()
       }
-      this.saveTemplate()
     },
     updateOperatorAndVariables(id, value, type) {
       this.selected = {
@@ -279,8 +277,6 @@ export default {
         id,
         value: getNativeValueFromMarkupArgumentType(value, type),
       })
-      this.tryDataRequest()
-      this.saveTemplate()
     },
   },
 }

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,7 +6,7 @@ export const EDITOR_EXPORT_FORMAT = {
 }
 
 export const EDITOR_TRY_INTERVAL = 3000
-export const EDITOR_SAVE_INTERVAL = 5000
+export const EDITOR_SAVE_INTERVAL = 1000
 
 export const EDITOR_STAGES = {
   SETTINGS: 'settings',

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,6 +5,8 @@ export const EDITOR_EXPORT_FORMAT = {
   js: 'js',
 }
 
+export const EDITOR_TRY_INTERVAL = 3000
+
 export const EDITOR_STAGES = {
   SETTINGS: 'settings',
   SOURCES: 'sources',

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ export const EDITOR_EXPORT_FORMAT = {
 }
 
 export const EDITOR_TRY_INTERVAL = 3000
+export const EDITOR_SAVE_INTERVAL = 5000
 
 export const EDITOR_STAGES = {
   SETTINGS: 'settings',

--- a/src/store/rad.js
+++ b/src/store/rad.js
@@ -44,6 +44,8 @@ export default {
     variablesIndex: 0,
     hasVariables: false,
     subscriptIds: [],
+    autoTry: false,
+    dataRequestChanged: false,
   },
   getters: {
     currentTemplate: state => {
@@ -59,6 +61,13 @@ export default {
     },
     clearSubscriptIds: function(state) {
       state.subscriptIds = []
+    },
+    setDataRequestChanged(state, payload) {
+      state.dataRequestChanged = payload.value
+    },
+    toggleTryDataRequest(state) {
+      state.autoTry = !state.autoTry
+      state.dataRequestChanged = true
     },
     [SET_CURRENT_STAGE](state, { stage }) {
       state.currentStage = stage
@@ -140,6 +149,8 @@ export default {
       state.historyIndex = 0
     },
     [UPDATE_HISTORY](state, { mir }) {
+      // activate flag to try data request
+      state.dataRequestChanged = true
       state.stageHistory.push(state.currentStage)
       state.history.push(mir)
       state.historyIndex += 1
@@ -284,6 +295,9 @@ export default {
       }
     },
     [SET_CURRENT_TEMPLATE](state, { id }) {
+      this.autoTry = false
+      this.dataRequestChanged = false
+
       const template = state.templates[id]
       state.currentTemplate = template
       state.currentRadonMarkupInterpreter = new Radon(template.radRequest)

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -598,7 +598,7 @@ export default {
       })
     },
     tryDataRequest: async function(context) {
-      context.commit('setDataRequestChanged', { value: false }, { root: true })
+      context.commit('setDataRequestChangedSinceTried', { value: false }, { root: true })
       context.commit('generateRadRequestResultLoading', { root: true })
       context.rootState.rad.currentTemplate.usedVariables.forEach(variable => {
         const id = variable.id

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -598,7 +598,6 @@ export default {
       })
     },
     tryDataRequest: async function(context) {
-      context.commit('setDataRequestChangedSinceTried', { value: false }, { root: true })
       context.commit('generateRadRequestResultLoading', { root: true })
       context.rootState.rad.currentTemplate.usedVariables.forEach(variable => {
         const id = variable.id

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -598,6 +598,7 @@ export default {
       })
     },
     tryDataRequest: async function(context) {
+      context.commit('setDataRequestChanged', { value: false }, { root: true })
       context.commit('generateRadRequestResultLoading', { root: true })
       context.rootState.rad.currentTemplate.usedVariables.forEach(variable => {
         const id = variable.id

--- a/src/styles/element-variables.scss
+++ b/src/styles/element-variables.scss
@@ -7,6 +7,16 @@ $--color-success: #52c41a;
 /* icon font path, required */
 $--font-path: '~element-ui/lib/theme-chalk/fonts';
 
+.el-switch {
+  .el-switch__label {
+    color: $white;
+
+    &.is-active {
+      color: $white;
+    }
+  }
+}
+
 .el-input--mini .el-input__inner {
   background-color: $black;
   border-color: #c5c2c2;

--- a/src/utils.js
+++ b/src/utils.js
@@ -302,7 +302,7 @@ export function copyToClipboard(str) {
 // Get the native javascript type from the radon markup argument type
 export function getNativeValueFromMarkupArgumentType(value, type) {
   if (type === 'number') {
-    return Number(value)
+    return Number(value) || value === '0' ? Number(value) : null
   }
   if (type === 'boolean') {
     return value === 'true'

--- a/tests/unit/src/components/EditorToolbar.spec.js
+++ b/tests/unit/src/components/EditorToolbar.spec.js
@@ -229,41 +229,6 @@ describe('EditorToolBar.vue', () => {
       expect(mockEditorUndo).toHaveBeenCalled()
     })
 
-    it('try', async () => {
-      const mockEditorUndo = jest.fn()
-      const mockEditorRedo = jest.fn()
-      const mockTryDataRequest = jest.fn()
-      const mockSaveTemplate = jest.fn()
-
-      const wrapper = mount(
-        EditorToolBar,
-        createComponentMocks({
-          router: true,
-          store: {
-            rad: {
-              namespaced: false,
-              state: {
-                currentTemplate: { name: 'Template 1' },
-              },
-              mutations: {
-                [EDITOR_UNDO]: mockEditorUndo,
-                [EDITOR_REDO]: mockEditorRedo,
-              },
-              actions: {
-                tryDataRequest: mockTryDataRequest,
-                saveTemplate: mockSaveTemplate,
-              },
-            },
-          },
-        }),
-      )
-
-      const tryButton = wrapper.find('[data-test="action-try"]')
-      await tryButton.trigger('click')
-
-      expect(mockTryDataRequest).toHaveBeenCalled()
-    })
-
     it('deploy', async () => {
       const mockEditorUndo = jest.fn()
       const mockEditorRedo = jest.fn()


### PR DESCRIPTION
This pr uses the new autosave behavior in #1288 to try data request automatically only when the switch is activated.

Close #1243 