### PR TITLE
fix: delete repeated description

### DIFF
--- a/src/claimingDisclaimers.js
+++ b/src/claimingDisclaimers.js
@@ -3,7 +3,6 @@ export default [
     title: 'Hey, listen!',
     nextText: 'I will be careful, I promise!',
     content: [
-      'A wallet is an app that keeps your credentials safe and lets you interface with the Witnet blockchain in many ways: from transferring Wit to someone else to creating smart contracts.',
       'You should never share your seed phrase with anyone. We at Witnet do not store your seed phrase and will never ask you to share it with us. If you lose your seed phrase, you will permanently lose access to your wallet and your funds.',
       'If someone finds or sees your seed phrase, they will have access to your wallet and all of your funds.',
       'We recommend storing your seed phrase on paper somewhere safe. Do not store it in a file on your computer or anywhere electronically.',


### PR DESCRIPTION
This PR deletes the description that was included twice in the claiming process.

Closes #1370 