### PR TITLE
fix: disable copy mnemonics in claiming process

### DIFF
--- a/src/components/claiming/WalletSeedBackup.vue
+++ b/src/components/claiming/WalletSeedBackup.vue
@@ -56,7 +56,7 @@ export default {
         }
       },
     }),
-    disableCopyMnemonics() {
+    isCopyMnemonicsDisabled() {
       return process.env.NODE_ENV !== 'development'
     },
   },

--- a/src/components/claiming/WalletSeedBackup.vue
+++ b/src/components/claiming/WalletSeedBackup.vue
@@ -56,6 +56,9 @@ export default {
         }
       },
     }),
+    disableCopyMnemonics() {
+      return process.env.NODE_ENV !== 'development'
+    },
   },
   beforeCreate() {
     this.$store.dispatch('createMnemonics')
@@ -112,10 +115,9 @@ export default {
   padding: 24px;
   white-space: pre-wrap;
   width: 100%;
+}
 
-  &:hover {
-    border: $input_big-hover-border;
-    box-shadow: $input_big-hover-box-shadow;
-  }
+.copy-disabled {
+  user-select: none;
 }
 </style>

--- a/src/components/steps/WalletSeedBackup.vue
+++ b/src/components/steps/WalletSeedBackup.vue
@@ -12,7 +12,7 @@
     <pre
       data-test="word-seed"
       class="seed"
-      :class="{ 'copy-disabled': disableCopyMnemonics }"
+      :class="{ 'copy-disabled': isCopyMnemonicsDisabled }"
       >{{ seed }}</pre
     >
     <p class="paragraph">
@@ -40,7 +40,7 @@ export default {
     ...mapState({
       seed: state => state.wallet.mnemonics,
     }),
-    disableCopyMnemonics() {
+    isCopyMnemonicsDisabled() {
       return process.env.NODE_ENV !== 'development'
     },
   },


### PR DESCRIPTION
This PR disable the copy of the seed phrase in the claiming process.

Closes #1372 
