### PR TITLE
Fix: not show several addresses if only one repeated

### DIFF
--- a/src/components/Amount.vue
+++ b/src/components/Amount.vue
@@ -2,7 +2,7 @@
   <div class="amount-container" data-test="amount" @click="callChangeCurrency">
     <el-tooltip
       v-if="standardizeWitUnits(amount, currency).length > 13"
-      :content="'hola'"
+      :content="amount"
       placement="bottom"
       effect="light"
     >

--- a/src/components/Transaction.vue
+++ b/src/components/Transaction.vue
@@ -167,7 +167,8 @@ export default {
   computed: {
     address() {
       if (this.type === 'POSITIVE') {
-        return this.inputs.length > 1
+        return this.inputs.length > 1 &&
+          this.inputs.some(input => input.address !== this.inputs[0].address)
           ? 'several addresses'
           : this.inputs[0].address
       } else {


### PR DESCRIPTION
Some tx where set as several addresses but actually was just one repeated, now it shows only the address
Closes #1397 