### PR TITLE
fix: show transactions with 0 inputs as "from genesis"

### DIFF
--- a/src/components/Transaction.vue
+++ b/src/components/Transaction.vue
@@ -167,10 +167,17 @@ export default {
   computed: {
     address() {
       if (this.type === 'POSITIVE') {
-        return this.inputs.length > 1 &&
+        if (
+          this.inputs.length > 1 &&
           this.inputs.some(input => input.address !== this.inputs[0].address)
-          ? 'several addresses'
-          : this.inputs[0].address
+        ) {
+          return 'several addresses'
+        } else if (this.inputs.length > 0) {
+          return this.inputs[0].address
+        } else {
+          // this.inputs.length == 0: assume this is a genesis transaction
+          return 'genesis'
+        }
       } else {
         // We are assumming that the first output is the address where we are
         // sending and the second is for the change. So if there are more than 2,


### PR DESCRIPTION
# PR Prelude

Thank you for contributing to sheikah! :)

**Please fill in this template (by putting an `x` inside
the brackets) _before_ filing your PR:**

- [ ] I have read and understood [CODE_OF_CONDUCT][code] document.
- [ ] I have read and understood [CONTRIBUTING][cont] document.
- [ ] I have read and understood [STYLEGUIDE][style] document.
- [ ] I have included tests for the changes in my PR. If not, I have included a
  rationale for why I haven't.
- [ ] My code is formatted and is accepted by `yarn lint`.
- [ ] **I understand my PR may be closed if it becomes obvious I didn't
  actually perform all of these steps.**

# Why this change is necessary and useful

[Please explain **in detail** why the changes in this PR are needed.]

[code]: https://github.com/witnet/sheikah/blob/master/.github/CODE_OF_CONDUCT.md
[cont]: https://github.com/witnet/sheikah/blob/master/.github/CONTRIBUTING.md
[style]: https://github.com/witnet/sheikah/blob/master/docs/STYLEGUIDE.md
