### PR TITLE
chore: remove --trace flag from wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Once this has been achieved, you can run a `witnet-node` and a `witnet-wallet`.
 #### witnet-wallet
 
 ```bash
-./witnet --trace wallet server
+./witnet wallet server
 ```
 
 ### Running Sheikah

--- a/src/background.js
+++ b/src/background.js
@@ -416,7 +416,6 @@ async function runWallet() {
     walletProcess = cp.spawn(path.join(SHEIKAH_PATH, WITNET_FILE_NAME), [
       '-c',
       walletConfigurationPath,
-      '--trace',
       'wallet',
       'server',
     ])


### PR DESCRIPTION
# Why this change is necessary and useful

As it is currently impossible to see logs on certain platforms, the wallet can get a slight performance boost by moving the log level to info. Developers can still use the trace log level by setting it in witnet.toml or setting the environment variable `RUST_LOG=witnet=trace` when starting sheikah.

There are 3 ways to set the log level of the wallet, in order:

* `[log] level = "info"` in witnet.toml
* RUST_LOG environment variable
* `--trace`, `--debug` command line arguments when starting wallet

The `--trace` flag always forces the log level to trace, so it is impossible to change it to info. The default log level in witnet.toml is info, so removing this flag will set the log level to info.

