### PR TITLE
Update witnet-radon-js and simplify SettingsLanguage

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "vue-observe-visibility": "^0.4.6",
     "vue-router": "^3.0.3",
     "vuex": "^3.0.1",
-    "witnet-radon-js": "0.8.1"
+    "witnet-radon-js": "0.8.4"
   },
   "devDependencies": {
     "@babel/compat-data": "7.9.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@ export default {
     this.getTheme()
     this.getNotifications()
     this.getUnit()
-    this.getLanguage({ i18n: this.$i18n })
+    this.getLocale({ i18n: this.$i18n })
     // Disable back and forward from keyboard and mouse buttons
     window.onpopstate = function(event) {
       event.stopImmediatePropagation()
@@ -67,7 +67,7 @@ export default {
       getNotifications: 'getNotifications',
       getTheme: 'getTheme',
       getUnit: 'getUnit',
-      getLanguage: 'getLanguage',
+      getLocale: 'getLocale',
     }),
     pollData() {
       this.polling = setInterval(() => {

--- a/src/components/DeployDataRequest.vue
+++ b/src/components/DeployDataRequest.vue
@@ -103,11 +103,13 @@ export default {
       networkStatus: state => state.wallet.networkStatus,
       createDataRequestError: state => state.wallet.errors.createDataRequest,
       sendTransactionError: state => state.wallet.errors.sendTransaction,
+      locale: state => state.wallet.locale,
     }),
   },
   created() {
     this.setCurrentTemplate({
       id: this.template.id,
+      locale: this.locale,
     })
   },
   methods: {

--- a/src/components/EditorToolBar.vue
+++ b/src/components/EditorToolBar.vue
@@ -139,6 +139,7 @@ export default {
       radRequest: state => state.rad.radRequest,
       autoTry: state => state.rad.autoTry,
       currentStatus: state => state.wallet.status.currentState,
+      locale: state => state.wallet.locale,
     }),
     dataStr() {
       return this.exportFormat === EDITOR_EXPORT_FORMAT.JSON
@@ -197,11 +198,11 @@ export default {
       }
     },
     editorUndo() {
-      this.undo()
+      this.undo({ locale: this.locale })
       this.$emit('undo-redo')
     },
     editorRedo() {
-      this.redo()
+      this.redo({ locale: this.locale })
       this.$emit('undo-redo')
     },
     handleCommand(action) {

--- a/src/components/SettingsLanguage.vue
+++ b/src/components/SettingsLanguage.vue
@@ -14,7 +14,7 @@
 import Card from '@/components/card/Card.vue'
 import Select from '@/components/Select.vue'
 import { LANGUAGES } from '@/constants'
-import { mapState, mapMutations } from 'vuex'
+import { mapMutations, mapGetters } from 'vuex'
 
 export default {
   name: 'SettingsOptionCurrenty',
@@ -22,27 +22,33 @@ export default {
   data() {
     return {
       options: Object.values(LANGUAGES).map(language => ({
-        primaryText: language,
-        value: language,
+        primaryText: language.name,
+        value: language.locale,
       })),
     }
   },
   computed: {
-    ...mapState({
-      language: state => state.wallet.language,
+    ...mapGetters({
+      language: 'language',
     }),
     actualLanguage: {
       set(val) {
-        this.changeLanguage({ language: val.value, i18n: this.$i18n })
+        this.changeLocale({ locale: val.value, i18n: this.$i18n })
       },
       get() {
-        return { primaryText: this.language, value: this.language }
+        return { primaryText: this.language.name, value: this.language.locale }
       },
+    },
+  },
+  watch: {
+    language(val) {
+      this.updateDRLanguage(val)
     },
   },
   methods: {
     ...mapMutations({
-      changeLanguage: 'changeLanguage',
+      changeLocale: 'changeLocale',
+      updateDRLanguage: 'updateDRLanguage',
     }),
   },
 }

--- a/src/components/Templates.vue
+++ b/src/components/Templates.vue
@@ -107,6 +107,7 @@ export default {
           .sort(
             (a, b) => parseInt(b.lastTimeOpened) - parseInt(a.lastTimeOpened),
           ),
+      locale: state => state.wallet.locale,
     }),
   },
   beforeMount() {
@@ -134,7 +135,7 @@ export default {
       this.dialogVisible = false
     },
     createTemplateAndRedirect() {
-      this.createTemplate()
+      this.createTemplate({ locale: this.locale })
       this.$router.push('/request/editor')
     },
     handleDeleteTemplate({ id }) {

--- a/src/components/card/TemplateCard.vue
+++ b/src/components/card/TemplateCard.vue
@@ -140,6 +140,7 @@ export default {
   computed: {
     ...mapState({
       currentStatus: state => state.wallet.status.currentState,
+      locale: state => state.wallet.locale,
     }),
     style() {
       return this.type
@@ -164,7 +165,7 @@ export default {
     },
     edit() {
       this.$router.push('/request/editor')
-      this.setCurrentTemplate({ id: this.id })
+      this.setCurrentTemplate({ id: this.id, locale: this.locale })
     },
     handleCommand(index) {
       this.options[index].action()

--- a/src/constants.js
+++ b/src/constants.js
@@ -25,11 +25,6 @@ export const SOURCES_WITH_REDUCED_DISCLAIMERS = [
   'founder',
 ]
 
-export const LANGUAGES = {
-  ES: 'Español',
-  EN: 'English',
-}
-
 export const CUSTOM_ICON_NAMES = [
   'add-operator',
   'add',
@@ -55,12 +50,18 @@ export const CUSTOM_ICON_NAMES = [
   'up',
 ]
 
-export const LOCALES = {
-  [LANGUAGES.ES]: 'es',
-  [LANGUAGES.EN]: 'en',
+export const LANGUAGES = {
+  es: { name: 'Español', locale: 'es' },
+  en: { name: 'English', locale: 'en' },
 }
 
-export const DEFAULT_LANGUAGE = LANGUAGES.EN
+export const LOCALES = {
+  es: 'es',
+  en: 'en',
+}
+
+export const DEFAULT_LOCALE = 'en'
+
 export const THEMES = {
   LIGHT: 'light',
   DARK: 'dark',
@@ -161,7 +162,7 @@ export const SETTINGS_SECTIONS = {
 
 export const SETTINGS_BY_SECTION = {
   // TODO: include SETTINGS.LASGUAGE within general settings section when the transalations are ready
-  GENERAL: [SETTINGS.UNIT, SETTINGS.APPEARANCE],
+  GENERAL: [SETTINGS.UNIT, SETTINGS.LANGUAGE, SETTINGS.APPEARANCE],
   ADVANCED: [SETTINGS.EXPORT_XPRV, SETTINGS.RESYNC],
   NOTIFICATIONS: [SETTINGS.NOTIFICATIONS],
   ABOUT: [SETTINGS.COMMUNITY],

--- a/src/plugins/i18n.js
+++ b/src/plugins/i18n.js
@@ -21,7 +21,8 @@ Vue.use(VueI18n)
 // }
 
 export default new VueI18n({
-  locale: navigator.language || navigator.languages[0],
+  locale:
+    navigator.language.split('-')[0] || navigator.languages[0].split('-')[0],
   fallbackLocale: 'en',
   messages: {
     en: require('@/locales/en.json'),

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -22,7 +22,7 @@ import {
   NETWORK_STATUS,
   TRANSACTIONS_LIMIT,
   NOTIFICATIONS,
-  DEFAULT_LANGUAGE,
+  DEFAULT_LOCALE,
   LANGUAGES,
   LOCALES,
   THEMES,
@@ -68,7 +68,7 @@ export default {
     mainnetReady: false,
     theme: null,
     unit: DEFAULT_WIT_UNIT,
-    language: DEFAULT_LANGUAGE,
+    locale: DEFAULT_LOCALE,
     prevUnit: DEFAULT_WIT_UNIT,
     balance: {},
     walletIdx: null,
@@ -127,6 +127,11 @@ export default {
     estimatedTimeOfSync: state => {
       return formatMillisecondsDuration(state.syncingTimeEstimator.calculate())
     },
+    language: state => {
+      return Object.values(LANGUAGES).find(
+        language => language.locale === state.locale,
+      )
+    },
   },
   mutations: {
     setWalletOwner(status, { isDefaultWallet }) {
@@ -156,12 +161,12 @@ export default {
     setUnit(state, unit) {
       state.unit = unit
     },
-    setLanguage(state, { language, i18n }) {
-      if (language) {
-        state.language = language
-        i18n.locale = LOCALES[state.language]
+    setLanguage(state, { locale, i18n }) {
+      if (locale) {
+        state.locale = locale
+        i18n.locale = LOCALES[state.locale]
       } else {
-        state.language = LANGUAGES[i18n.locale.toUpperCase()]
+        state.locale = LANGUAGES[i18n.locale.toUpperCase()]
       }
     },
     setTheme(state, theme) {
@@ -229,11 +234,12 @@ export default {
         state.balance = balance
       }
     },
-    changeLanguage(state, payload) {
-      if (Object.values(LANGUAGES).includes(payload.language)) {
-        state.language = payload.language
-        state.localStorage.setLanguageSettings(state.language)
-        payload.i18n.locale = LOCALES[state.language]
+    changeLocale(state, { locale, i18n }) {
+      if (Object.keys(LOCALES).includes(locale)) {
+        state.locale = locale
+        state.localStorage.setLanguageSettings(locale)
+
+        i18n.locale = locale
       } else {
         console.warn('[mutation setUnit]: invalid language')
       }
@@ -874,16 +880,12 @@ export default {
         ? context.commit('setUnit', unit)
         : context.commit('setUnit', defaultUnit)
     },
-    getLanguage: async function(context, payload) {
-      const language = context.state.localStorage.getLanguageSettings()
-      if (language) {
+    getLocale: async function(context, payload) {
+      const locale = context.state.localStorage.getLanguageSettings()
+
+      if (locale) {
         context.commit('setLanguage', {
-          language: language,
-          i18n: payload.i18n,
-        })
-      } else {
-        context.commit('setLanguage', {
-          language: null,
+          locale: locale,
           i18n: payload.i18n,
         })
       }

--- a/tests/unit/src/components/SettingsLanguage.spec.js
+++ b/tests/unit/src/components/SettingsLanguage.spec.js
@@ -2,7 +2,7 @@ import SettingsLanguage from '@/components/SettingsLanguage'
 
 describe('SettingsLanguage.vue', () => {
   describe('change language', () => {
-    const changeLanguageMock = jest.fn()
+    const changeLocaleMock = jest.fn()
 
     it('should call the mutation to change the unit', async () => {
       const wrapper = mount(
@@ -15,24 +15,32 @@ describe('SettingsLanguage.vue', () => {
                 language: 'English',
               },
               mutations: {
-                changeLanguage: changeLanguageMock,
+                changeLocale: changeLocaleMock,
+              },
+              getters: {
+                language: () => {
+                  return 'English'
+                },
               },
             },
           },
         }),
       )
+
       wrapper.setData({
         options: [
           { primaryText: 'Español', value: 'Español' },
           { primaryText: 'English', value: 'English' },
         ],
       })
+
       const selectButton = wrapper.find('[data-test="select-btn"]')
       await selectButton.trigger('click')
 
       const option2Button = wrapper.find('[data-test="option-0"]')
       await option2Button.trigger('click')
-      expect(changeLanguageMock).toHaveBeenCalled()
+
+      expect(changeLocaleMock).toHaveBeenCalled()
     })
 
     it('the language should be English on change', async () => {
@@ -46,7 +54,12 @@ describe('SettingsLanguage.vue', () => {
                 language: 'English',
               },
               mutations: {
-                changeLanguage: changeLanguageMock,
+                changeLocale: changeLocaleMock,
+              },
+              getters: {
+                language: () => {
+                  return 'English'
+                },
               },
             },
           },
@@ -79,7 +92,12 @@ describe('SettingsLanguage.vue', () => {
                 language: 'English',
               },
               mutations: {
-                changeLanguage: changeLanguageMock,
+                changeLocale: changeLocaleMock,
+              },
+              getters: {
+                language: () => {
+                  return 'English'
+                },
               },
             },
           },

--- a/tests/unit/src/utils.spec.js
+++ b/tests/unit/src/utils.spec.js
@@ -638,7 +638,7 @@ describe('calculateCurrentFocusAfterUndo', () => {
               kind: 'HTTP-GET',
               url: 'asd',
               contentType: 'JSON API',
-              script: [112, [33, '', true]],
+              script: [112, 32],
             },
             {
               kind: 'HTTP-GET',
@@ -835,7 +835,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
                 kind: 'HTTP-GET',
                 url: '',
                 contentType: 'JSON API',
-                script: [112, [33, '', true], 16, 64],
+                script: [112, 34, 16, 64],
               },
             ],
             aggregate: { filters: [], reducer: 2 },
@@ -852,7 +852,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
               kind: 'HTTP-GET',
               url: '',
               contentType: 'JSON API',
-              script: [112, [33, '', true], 16],
+              script: [112, 34, 16],
             },
           ],
           aggregate: { filters: [], reducer: 2 },
@@ -866,7 +866,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
           variables,
         )
 
-        expect(id).toBe(7)
+        expect(id).toBe(5)
       })
 
       it('on aggregation tally stage', () => {
@@ -878,7 +878,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
                 kind: 'HTTP-GET',
                 url: '',
                 contentType: 'JSON API',
-                script: [112, [33, '', true], 16, 64],
+                script: [112, 34, 16, 64],
               },
             ],
             aggregate: {
@@ -902,7 +902,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
               kind: 'HTTP-GET',
               url: '',
               contentType: 'JSON API',
-              script: [112, [33, '', true], 16, 64],
+              script: [112, 34, 16, 64],
             },
           ],
           aggregate: {
@@ -923,7 +923,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
           variables,
         )
 
-        expect(id).toBe(12)
+        expect(id).toBe(10)
       })
     })
 
@@ -1063,7 +1063,7 @@ describe('calculateCurrentFocusAfterRedo', () => {
             kind: 'HTTP-GET',
             url: '',
             contentType: 'JSON API',
-            script: [112, [33, '', true]],
+            script: [112, 34],
           },
           { kind: 'HTTP-GET', url: '', contentType: 'JSON API', script: [114] },
         ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -5151,6 +5151,11 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+dlv@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/dlv/-/dlv-1.1.3.tgz#5c198a8a11453596e751494d49874bc7732f2e79"
+  integrity sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==
+
 dmg-builder@22.8.0:
   version "22.8.0"
   resolved "https://registry.yarnpkg.com/dmg-builder/-/dmg-builder-22.8.0.tgz#2b17127837ed444db3086317eda5cf8912f6e6a9"
@@ -12732,6 +12737,14 @@ roarr@^2.15.3:
     semver-compare "^1.0.0"
     sprintf-js "^1.1.2"
 
+rosetta@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rosetta/-/rosetta-1.1.0.tgz#41ecc0f3cb38ce34b981b0dcfca2f4c94721738c"
+  integrity sha512-3jQaCo2ySoDqLIPjy7+AvN3rluLfkG8A27hg0virL0gRAB5BJ3V35IBdkL/t6k1dGK0TVTyUEwXVUJsygyx4pA==
+  dependencies:
+    dlv "^1.1.3"
+    templite "^1.1.0"
+
 rpc-websockets@^4.3.5:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-4.6.1.tgz#589415223dff7669577e8a463694e1cdd0eb81bf"
@@ -13951,6 +13964,11 @@ temp-file@^3.3.7:
   dependencies:
     async-exit-hook "^2.0.1"
     fs-extra "^8.1.0"
+
+templite@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/templite/-/templite-1.1.0.tgz#4f2eab732234fdac996628427d72817b3a47ce06"
+  integrity sha512-DtXicIurbnJS5/eu3nMLLspt4bZ8F/811IpcI7DgSE63UhES6ld3CxoTcLXBuGhliYx2wMVmyNzHf3c7mqwIIA==
 
 term-size@^2.1.0:
   version "2.2.0"
@@ -15448,13 +15466,14 @@ with@^7.0.0:
     assert-never "^1.2.1"
     babel-walk "3.0.0-canary-5"
 
-witnet-radon-js@0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/witnet-radon-js/-/witnet-radon-js-0.8.1.tgz#f6f2d8b313dadd865f52658750fd30903cd8cb27"
-  integrity sha512-gO/X2wIx3meGMOSZoJW8hVeGnmcbjqYt3nQ3w8VL1CzWeqKSvdYCoDllSIIMmjlA1kM0RebBzD/uKcY0UTn/Wg==
+witnet-radon-js@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/witnet-radon-js/-/witnet-radon-js-0.8.4.tgz#aea3245a94bcb4dd56420016949adf3154e3c92c"
+  integrity sha512-cruud9vfjIWNHmWLS6GFZVfQlcdj5eTF21+yuXdFJPjzfrLgJNWyshl4x90DXsyeeOEV67n1mPcPC7h479UGcw==
   dependencies:
     json5 "^2.1.3"
     prettier "^2.0.5"
+    rosetta "^1.1.0"
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This PR have to be merged after [witnet#witnet-radon-js/44](https://github.com/witnet/witnet-radon-js/pull/44) and witnet-radon-js v0.8.2 is released.

- Upgrade `witnet-radon-js` to 0.8.4. Now Radon class accepts a locale argument to set the language of the descriptions. Also, expose a method `setLocale`, which we call to update the language of the current template.
- Simplify language settings flow. Now we store the locale, and we derive the language from it instead of doing it the other way around. This change makes it easier to add specific country locales in the future.
