### PR TITLE
 ci(gh-actions): setup automatic builds and releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,40 @@
+name: Build
+
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy: 
+      matrix:
+        os: [
+          macos-latest, 
+          ubuntu-latest, 
+          windows-latest
+        ]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.20.2
+      - name: Build Electron app
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGN: false
+        run: |
+          yarn
+          yarn electron:build --publish="never"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          # Artifact name
+          name: ${{ matrix.os }}-artifact
+          # Directory containing files to upload
+          path: dist_electron

--- a/.github/workflows/lintAndTest.yaml
+++ b/.github/workflows/lintAndTest.yaml
@@ -1,13 +1,9 @@
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+name: Run lint and test 
 
-  workflow_dispatch:
+on: pull_request
 
 jobs:
-  ci:
+  lint_and_test:
     runs-on: ubuntu-latest
 
     steps:
@@ -19,4 +15,3 @@ jobs:
       - run: yarn install
       - run: yarn lint:check
       - run: yarn test 
-      - run: yarn electron:build --publish=never 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: Release a draft release 
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+    strategy: 
+      matrix:
+        os: [
+          macos-latest, 
+          ubuntu-latest, 
+          windows-latest
+          ]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: 12.20.2
+      
+      - name: Build & release Electron app
+        shell: bash
+        env:
+          # macOS Code signing certificates
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # macOS notarization API key
+          APPLEID: ${{ secrets.APPLEID }}
+          APPLEIDPASS: ${{ secrets.APPLEIDPASSWORD }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGN: true
+        run: |
+          yarn
+          yarn electron:build --publish="always"
+      - name: Upload artifact
+        uses: actions/upload-artifact@v1.0.0
+        with:
+          # Artifact name
+          name: ${{ matrix.os }}-artifact
+          # Directory containing files to upload
+          path: dist_electron

--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ When opening a pull request a job in [Travis](https://travis-ci.com/) will be fi
 
 If the application doesn't boot correctly and no error is reported in the terminal, try running `yarn reinstall` and try again.
 
+
+
+## Release
+Releases are created using [action-electron-builder](https://github.com/samuelmeuli/action-electron-builder). A new draft release will be publish naming a commit and a tag as v*.*.*

--- a/scripts/notarize.js
+++ b/scripts/notarize.js
@@ -3,7 +3,18 @@ const { notarize } = require('electron-notarize')
 
 exports.default = async function notarizing(context) {
   const { electronPlatformName, appOutDir } = context
+
+  // skip notarization for no macOS platforms
   if (electronPlatformName !== 'darwin') {
+    return
+  }
+
+  // Skip notarization when SIGN env is false
+  if (
+    !process.env.SIGN ||
+    process.env.SIGN === 'false' ||
+    process.env.SIGN === '0'
+  ) {
     return
   }
 

--- a/src/background.js
+++ b/src/background.js
@@ -516,8 +516,7 @@ autoUpdater.on('update-downloaded', () => {
     setImmediate(() => {
       autoUpdater.quitAndInstall()
     })
-  }
-  catch(err) {
+  } catch (err) {
     console.log(err)
   }
 })

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,6 +5,7 @@ module.exports = {
     electronBuilder: {
       builderOptions: {
         linux: {
+          target: ['AppImage'],
           category: 'Network',
         },
         mac: {
@@ -14,6 +15,12 @@ module.exports = {
           gatekeeperAssess: false,
         },
         afterSign: 'scripts/notarize.js',
+        publish: [
+          {
+            provider: 'github',
+            releaseType: 'draft',
+          },
+        ],
       },
       nodeIntegration: true,
     },


### PR DESCRIPTION
close #1659 

This PR adds two new github actions: build and release.

- `build` is triggered on every pull request. It tries to build Sheikah on `macos-latest`, `ubuntu-latest` and `windows-latest`.
- `release` is triggered when someone pushes into master. This action checks if the commit name and the tag name and then it drafts a new release.