### PR TITLE
fix: improve timelock ux

### DIFF
--- a/src/components/SendValueTransferForm.vue
+++ b/src/components/SendValueTransferForm.vue
@@ -75,7 +75,7 @@
       </el-button>
       <el-button
         class="send-btn"
-        tabindex="5"
+        tabindex="6"
         type="primary"
         data-test="sign-send-btn"
         @click="tryCreateVTT"
@@ -314,6 +314,7 @@ export default {
   .link {
     font-size: 14px;
     text-align: left;
+    width: fit-content;
 
     .icon {
       width: 8px;

--- a/src/components/SendValueTransferForm.vue
+++ b/src/components/SendValueTransferForm.vue
@@ -35,19 +35,46 @@
         <AppendUnit slot="append" :static-unit="WIT_UNIT.NANO" />
       </el-input>
     </el-form-item>
-    <el-form-item :label="$t('timelock')" prop="timelock">
-      <el-date-picker
-        v-model="form.timelock"
-        type="datetime"
-        placeholder="Select date and time"
-        tabindex="5"
-        :default-value="new Date()"
-        value-format="timestamp"
-      />
-    </el-form-item>
+    <transition name="slide">
+      <el-form-item
+        v-if="isAdvancedVisible"
+        :label="$t('timelock')"
+        prop="timelock"
+      >
+        <el-date-picker
+          v-model="form.timelock"
+          type="datetime"
+          :placeholder="$t('select_date')"
+          tabindex="5"
+          :default-value="new Date()"
+          value-format="timestamp"
+        />
+      </el-form-item>
+    </transition>
     <p v-if="createVTTError" class="error">{{ createVTTError.message }}</p>
     <div class="submit">
       <el-button
+        v-if="isAdvancedVisible"
+        data-test="advance-options"
+        type="text"
+        class="link"
+        @click="toggleAdvanceOptions"
+      >
+        {{ this.$t('show_less') }}
+        <CustomIcon class-name="icon" name="close" />
+      </el-button>
+      <el-button
+        v-else
+        data-test="show-advance-options"
+        class="link"
+        type="text"
+        @click="toggleAdvanceOptions"
+      >
+        {{ this.$t('show_advance') }}
+        <CustomIcon class-name="icon" name="open" />
+      </el-button>
+      <el-button
+        class="send-btn"
         tabindex="5"
         type="primary"
         data-test="sign-send-btn"
@@ -64,11 +91,13 @@ import { mapState, mapMutations, mapGetters } from 'vuex'
 import AppendUnit from '@/components/AppendUnit'
 import { standardizeWitUnits, isGrtMaxNumber } from '@/utils'
 import { WIT_UNIT } from '@/constants'
+import CustomIcon from '@/components/CustomIcon'
 
 export default {
   name: 'SendValueTransferForm',
   components: {
     AppendUnit,
+    CustomIcon,
   },
   data() {
     const maxNumber = (rule, value, callback) => {
@@ -200,6 +229,9 @@ export default {
       clearError: 'clearError',
       clearGeneratedTransaction: 'clearGeneratedTransaction',
     }),
+    toggleAdvanceOptions() {
+      this.isAdvancedVisible = !this.isAdvancedVisible
+    },
     changeUnit(prevUnit, newUnit) {
       this.form = {
         ...this.form,
@@ -274,7 +306,26 @@ export default {
 }
 
 .submit {
+  display: flex;
+  flex-direction: column;
   text-align: right;
   width: 100%;
+
+  .link {
+    font-size: 14px;
+    text-align: left;
+
+    .icon {
+      width: 8px;
+    }
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  .send-btn {
+    align-self: flex-end;
+  }
 }
 </style>

--- a/src/components/SettingsLanguage.vue
+++ b/src/components/SettingsLanguage.vue
@@ -33,7 +33,7 @@ export default {
     }),
     actualLanguage: {
       set(val) {
-        this.changeLocale({ locale: val.value, i18n: this.$i18n })
+        this.changeLocale({ newLocale: val.value, i18n: this.$i18n })
       },
       get() {
         return { primaryText: this.language.name, value: this.language.locale }

--- a/src/components/steps/WalletBirthdate.vue
+++ b/src/components/steps/WalletBirthdate.vue
@@ -15,7 +15,7 @@
       <el-date-picker
         v-model="birthDate"
         type="date"
-        placeholder="Pick a creation date"
+        :placeholder="$t('select_creation_date')"
         :picker-options="pickerOptions"
       >
       </el-date-picker>

--- a/src/components/steps/WalletImport.vue
+++ b/src/components/steps/WalletImport.vue
@@ -94,7 +94,7 @@ export default {
     async nextStep() {
       await this.validateForm()
       if (this.repeatedWallet) {
-        this.$router.push('/ftu/repeated-wallet')
+        this.$router.push('/ftu/repeated-wallet?import=true')
       } else if (!this.mnemonicsError) {
         this.$router.push(`/ftu/wallet-birthdate?import=true`)
       }

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,6 @@
-import { es, enGB } from 'date-fns/locale'
+import { es as fnsEs, enGB } from 'date-fns/locale'
+import en from 'element-ui/lib/locale/lang/en'
+import es from 'element-ui/lib/locale/lang/es'
 
 export const EDITOR_ALLOWED_PROTOCOLS = ['http', 'https']
 
@@ -34,8 +36,8 @@ export const SOURCES_WITH_REDUCED_DISCLAIMERS = [
 ]
 
 export const LANGUAGES = {
-  es: { name: 'Español', locale: 'es', fnsLocale: es },
-  en: { name: 'English', locale: 'en', fnsLocale: enGB },
+  es: { name: 'Español', locale: 'es', fnsLocale: fnsEs, elementLocale: es },
+  en: { name: 'English', locale: 'en', fnsLocale: enGB, elementLocale: en },
 }
 
 export const DEFAULT_LOCALE = 'en'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -399,5 +399,7 @@
   "export_name_and_description": "Include name and description",
   "select_wallet_birth_date": "Select wallet creation date",
   "wallet_birth_date_text": "By default, Sheikah will start looking for transactions from the genesis date. If remember when you created your wallet, you can specify it to start syncing from that date and boost up the synchronization speed.",
-  "timelock": "Timelock"
+  "timelock": "Timelock",
+  "select_date": "Select date and time",
+  "select_creation_date": "Pick a creation date"
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -398,5 +398,7 @@
   "timelock": "Timelock",
   "export_name_and_description": "Inlcuir nombre y descripción",
   "select_wallet_birth_date": "Seleccionar fecha de creación",
-  "wallet_birth_date_text": "Por defecto, Sheikah empezará a buscar transacciones desde la fecha del genesis. Si recuerdas cuando creaste tu wallet, puedes especificarlo para empezar a sincronizar desde esa fecha y disminuir el tiempo de sincronización"
+  "wallet_birth_date_text": "Por defecto, Sheikah empezará a buscar transacciones desde la fecha del genesis. Si recuerdas cuando creaste tu wallet, puedes especificarlo para empezar a sincronizar desde esa fecha y disminuir el tiempo de sincronización",
+  "select_date": "Selecciona la fecha y la hora",
+  "select_creation_date": "Selecciona una fecha de creación"
 }

--- a/src/plugins/element.js
+++ b/src/plugins/element.js
@@ -1,7 +1,5 @@
 import Vue from 'vue'
 import Element from 'element-ui'
-
 import '@/styles/element-variables.scss'
-import locale from 'element-ui/lib/locale/lang/es'
 
-Vue.use(Element, { locale })
+Vue.use(Element)

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -28,6 +28,7 @@ import {
 } from '@/constants'
 import { SET_TEMPLATES, UPDATE_TEMPLATE } from '@/store/mutation-types'
 import warning from '@/resources/svg/warning.png'
+import locale from 'element-ui/lib/locale'
 
 export default {
   state: {
@@ -247,15 +248,17 @@ export default {
         state.balance = balance
       }
     },
-    changeLocale(state, { locale, i18n }) {
-      if (Object.keys(LANGUAGES).includes(locale)) {
-        state.locale = locale
-        state.localStorage.setLanguageSettings(locale)
+    changeLocale(state, { newLocale, i18n }) {
+      if (Object.keys(LANGUAGES).includes(newLocale)) {
+        state.locale = newLocale
+        state.localStorage.setLanguageSettings(newLocale)
 
-        i18n.locale = locale
+        i18n.locale = newLocale
       } else {
         console.warn('[mutation setUnit]: invalid language')
       }
+      // Set element locale
+      locale.use(LANGUAGES[i18n.locale].elementLocale)
     },
     changeDefaultUnit(state, unit) {
       if (Object.values(WIT_UNIT).includes(unit)) {
@@ -1012,10 +1015,10 @@ export default {
         : context.commit('setUnit', defaultUnit)
     },
     getLocale: async function(context, payload) {
-      const locale = context.state.localStorage.getLanguageSettings()
-      if (locale) {
+      const localeFromStorage = context.state.localStorage.getLanguageSettings()
+      if (localeFromStorage) {
         context.commit('setLanguage', {
-          locale: locale,
+          locale: localeFromStorage,
           i18n: payload.i18n,
         })
       } else {
@@ -1027,6 +1030,8 @@ export default {
           i18n: payload.i18n,
         })
       }
+      // Set element locale
+      locale.use(LANGUAGES[payload.i18n.locale].elementLocale)
     },
     getTheme: async function(context) {
       const theme = context.state.localStorage.getThemeSettings()

--- a/src/store/wallet.js
+++ b/src/store/wallet.js
@@ -28,7 +28,7 @@ import {
 } from '@/constants'
 import { SET_TEMPLATES, UPDATE_TEMPLATE } from '@/store/mutation-types'
 import warning from '@/resources/svg/warning.png'
-import locale from 'element-ui/lib/locale'
+import elementLocale from 'element-ui/lib/locale'
 
 export default {
   state: {
@@ -258,7 +258,7 @@ export default {
         console.warn('[mutation setUnit]: invalid language')
       }
       // Set element locale
-      locale.use(LANGUAGES[i18n.locale].elementLocale)
+      elementLocale.use(LANGUAGES[i18n.locale].elementLocale)
     },
     changeDefaultUnit(state, unit) {
       if (Object.values(WIT_UNIT).includes(unit)) {
@@ -1031,7 +1031,7 @@ export default {
         })
       }
       // Set element locale
-      locale.use(LANGUAGES[payload.i18n.locale].elementLocale)
+      elementLocale.use(LANGUAGES[payload.i18n.locale].elementLocale)
     },
     getTheme: async function(context) {
       const theme = context.state.localStorage.getThemeSettings()

--- a/src/styles/element-variables.scss
+++ b/src/styles/element-variables.scss
@@ -358,6 +358,10 @@ $--font-path: '~element-ui/lib/theme-chalk/fonts';
   background: var(--date-picker-background);
   border-top: var(--date-picker-border);
   color: var(--text-medium-emphasis);
+
+  .el-button--text {
+    display: none;
+  }
 }
 
 .el-picker-panel {

--- a/styleguide/scripts.js
+++ b/styleguide/scripts.js
@@ -1,7 +1,6 @@
 import Vue from 'vue'
 import Element from 'element-ui'
 import '@/styles/element-variables.scss'
-import locale from 'element-ui/lib/locale/lang/es'
 import '@/fontAwesome.js'
 
-Vue.use(Element, { locale })
+Vue.use(Element)


### PR DESCRIPTION
This pr implements the suggestions from discussion #1701. 
The element-UI locale updates itself when the language changes and the date-picker input is hidden now behind the advance options button.

<img width="646" alt="Captura de pantalla 2021-06-08 a las 15 48 18" src="https://user-images.githubusercontent.com/16032491/121196787-0f63f200-c871-11eb-8f56-15bf06dcda71.png">
<img width="647" alt="Captura de pantalla 2021-06-08 a las 15 48 40" src="https://user-images.githubusercontent.com/16032491/121196779-0d019800-c871-11eb-961b-57b8139956a9.png">
