### PR TITLE
feat: allow to set supported witnet-rust version in code

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -43,6 +43,7 @@ const SHEIKAH_PATH_BY_PLATFORM = {
   linux: path.join(os.homedir(), '.sheikah'),
   win32: path.join(os.homedir(), '.sheikah'),
 }
+const WITNET_RUST_VERSION = '1.2'
 const VERSION_FILE_NAME = '.version'
 const SHEIKAH_PATH = process.env.TRAVIS
   ? ''
@@ -402,7 +403,7 @@ function main() {
 
           isLatestVersionCompatible = semver.satisfies(
             getVersionFromName(latestReleaseVersion),
-            `~${getVersionFromName(versionFile)}`,
+            `~${WITNET_RUST_VERSION}`,
           )
 
           if (versionFile !== latestReleaseVersion) {


### PR DESCRIPTION
# Why this change is necessary and useful

It allows new versions of sheikah to update to new versions of witnet-rust
