### PR TITLE
fix(Select): add button type to internal button

### DIFF
--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -8,6 +8,7 @@
       <button
         id="select-button"
         ref="button"
+        type="button"
         data-test="select-btn"
         aria-haspopup="listbox"
         aria-labelledby="select-label select-button"


### PR DESCRIPTION
In some devices, after clicking the button without type="button" attribute, Sheikah triggered a reaload