### PR TITLE
chore: use witnet_rust 1.5.6 as min version

### DIFF
--- a/src/background/constants.ts
+++ b/src/background/constants.ts
@@ -67,7 +67,7 @@ export const STATUS_PATH = {
 
 export const WITNET_CONFIG_FILE_NAME = 'witnet.toml'
 
-export const WITNET_RUST_VERSION = '1.5.0'
+export const WITNET_RUST_VERSION = '1.5.6'
 
 export const DEFAULT_WALLET_LOG_LEVEL = 'error'
 


### PR DESCRIPTION
The estimation fee was introduced in witnet-rust `1.5.3`. If we target the `1.5.0`, Sheikah can't estimate the fees using the wallet.