### PR TITLE
ci: use python@3.11 in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7' 
+          python-version: '3.11'
 
       - name: Build Electron app
         shell: bash


### PR DESCRIPTION
Python 2.7 is deprectaed and can't be used in setup-python.

More info: https://github.com/actions/setup-python/issues/672