### PR TITLE
fix: mac intel error `eglQueryDeviceAttributeXT: Bad attribute`

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -33,6 +33,11 @@ if (release().startsWith('6.1')) app.disableHardwareAcceleration()
 // Set application name for Windows 10+ notifications
 if (process.platform === 'win32') app.setAppUserModelId(app.getName())
 
+// Avoid error in intel: 'eglQueryDeviceAttributeXT: Bad attribute'
+if (process.platform === 'darwin' && process.arch === 'x64') {
+  app.disableHardwareAcceleration()
+}
+
 if (!app.requestSingleInstanceLock()) {
   app.quit()
   process.exit(0)


### PR DESCRIPTION
Fixes error in mac intel devices ```ERROR:gl_display.cc(497)] EGL Driver message (Error) eglQueryDeviceAttribEXT: Bad attribute.``` when running app